### PR TITLE
Add streaming support for Gemini responses

### DIFF
--- a/lib/core/data/clients/gemini/gemini_client.dart
+++ b/lib/core/data/clients/gemini/gemini_client.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:my_dreams/core/constants/constants.dart';
@@ -13,5 +15,20 @@ class GeminiClient {
 
   Future<Response<T>> post<T>(String path, {Map<String, dynamic>? data}) {
     return _dio.post<T>(path, data: data);
+  }
+
+  Stream<String> postStream(String path, {Map<String, dynamic>? data}) async* {
+    final response = await _dio.post<ResponseBody>(
+      path,
+      data: data,
+      options: Options(responseType: ResponseType.stream),
+    );
+
+    final stream = response.data?.stream;
+    if (stream == null) return;
+
+    await for (final chunk in stream) {
+      yield utf8.decode(chunk);
+    }
   }
 }

--- a/lib/modules/dream/data/datasources/gemini_datasource.dart
+++ b/lib/modules/dream/data/datasources/gemini_datasource.dart
@@ -1,3 +1,3 @@
 abstract class GeminiDatasource {
-  Future<String> getMeaning(String dreamText);
+  Stream<String> getMeaning(String dreamText);
 }

--- a/lib/modules/dream/data/datasources/gemini_datasource_impl.dart
+++ b/lib/modules/dream/data/datasources/gemini_datasource_impl.dart
@@ -1,4 +1,4 @@
-import 'package:dio/dio.dart';
+import 'dart:convert';
 import 'package:injectable/injectable.dart';
 import 'package:my_dreams/core/data/clients/gemini/gemini_client.dart';
 
@@ -11,22 +11,30 @@ class GeminiDatasourceImpl implements GeminiDatasource {
   GeminiDatasourceImpl({required GeminiClient client}) : _client = client;
 
   @override
-  Future<String> getMeaning(String dreamText) async {
-    final Response<Map<String, dynamic>> response = await _client.post(
-      '/models/gemini-2.0-flash:generateContent',
-      data: {
-        'contents': [
-          {
-            'parts': [
-              {'text': 'Fale o significado do meu sonho: $dreamText'},
-            ],
-          },
-        ],
-      },
-    );
+  Stream<String> getMeaning(String dreamText) async* {
+    final data = {
+      'contents': [
+        {
+          'parts': [
+            {'text': 'Fale o significado do meu sonho: $dreamText'},
+          ],
+        },
+      ],
+    };
 
-    return response.data?['candidates']?[0]?['content']?['parts']?[0]?['text']
-            as String? ??
-        '';
+    await for (final chunk in _client.postStream(
+      '/models/gemini-2.0-flash:streamGenerateContent',
+      data: data,
+    )) {
+      try {
+        final Map<String, dynamic> json = jsonDecode(chunk);
+        final String? text =
+            json['candidates']?[0]?['content']?['parts']?[0]?['text']
+                as String?;
+        if (text != null) yield text;
+      } catch (_) {
+        // ignore invalid chunks
+      }
+    }
   }
 }

--- a/lib/modules/dream/domain/repositories/dream_repository.dart
+++ b/lib/modules/dream/domain/repositories/dream_repository.dart
@@ -3,7 +3,7 @@ import 'package:my_dreams/core/domain/entities/failure.dart';
 import '../entities/dream_entity.dart';
 
 abstract class DreamRepository {
-  Future<EitherOf<AppFailure, DreamEntity>> analyzeDream({
+  Stream<EitherOf<AppFailure, DreamEntity>> analyzeDream({
     required String dreamText,
     required String userId,
   });

--- a/lib/modules/dream/domain/usecases/analyze_dream.dart
+++ b/lib/modules/dream/domain/usecases/analyze_dream.dart
@@ -14,16 +14,17 @@ class AnalyzeDreamParams {
 }
 
 @injectable
-class AnalyzeDreamUseCase implements UseCase<DreamEntity, AnalyzeDreamParams> {
+class AnalyzeDreamUseCase
+    implements StreamUsecase<DreamEntity, AnalyzeDreamParams> {
   final DreamRepository _repository;
 
   AnalyzeDreamUseCase({required DreamRepository dreamRepository})
     : _repository = dreamRepository;
 
   @override
-  Future<EitherOf<AppFailure, DreamEntity>> call(
+  Stream<EitherOf<AppFailure, DreamEntity>> call(
     AnalyzeDreamParams params,
-  ) async {
+  ) {
     return _repository.analyzeDream(
       dreamText: params.dreamText,
       userId: params.userId,

--- a/lib/modules/dream/presentation/controller/dream_states.dart
+++ b/lib/modules/dream/presentation/controller/dream_states.dart
@@ -4,6 +4,7 @@ abstract class DreamStates {
   DreamLoadingState loading() => DreamLoadingState();
   DreamFailureState failure(String message) => DreamFailureState(message);
   DreamAnalyzedState analyzed(DreamEntity dream) => DreamAnalyzedState(dream);
+  DreamStreamingState streaming(String answer) => DreamStreamingState(answer);
   DreamListLoadedState dreams(List<DreamEntity> list) =>
       DreamListLoadedState(list);
 }
@@ -26,4 +27,10 @@ class DreamListLoadedState extends DreamStates {
   final List<DreamEntity> dreamsList;
 
   DreamListLoadedState(this.dreamsList);
+}
+
+class DreamStreamingState extends DreamStates {
+  final String answer;
+
+  DreamStreamingState(this.answer);
 }

--- a/lib/modules/dream/presentation/dream_page.dart
+++ b/lib/modules/dream/presentation/dream_page.dart
@@ -29,11 +29,19 @@ class _DreamPageState extends State<DreamPage> {
       return const Center(child: CircularProgressIndicator());
     }
 
+    if (state is DreamStreamingState) {
+      return Expanded(
+        child: SingleChildScrollView(
+          child: Text(state.answer),
+        ),
+      );
+    }
+
     if (state is DreamAnalyzedState) {
-      return AnimatedOpacity(
-        opacity: 1,
-        duration: const Duration(milliseconds: 300),
-        child: Text(state.dream.answer.value),
+      return Expanded(
+        child: SingleChildScrollView(
+          child: Text(state.dream.answer.value),
+        ),
       );
     }
 


### PR DESCRIPTION
## Summary
- stream responses from Gemini API using a new `postStream` method
- expose streaming from `GeminiDatasourceImpl`
- update repository and use case to work with streams
- adapt `DreamBloc` and states for incremental responses
- show streamed message with scrolling on `DreamPage`

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a9da428e48322b2b481f239246c11