### PR TITLE
Update dream page into chat style

### DIFF
--- a/lib/modules/dream/presentation/widgets/chat_message_widget.dart
+++ b/lib/modules/dream/presentation/widgets/chat_message_widget.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:my_dreams/core/constants/constants.dart';
+import 'package:my_dreams/shared/themes/app_theme_constants.dart';
+
+class ChatMessage {
+  final String text;
+  final bool isUser;
+
+  ChatMessage({required this.text, required this.isUser});
+}
+
+class ChatMessageWidget extends StatelessWidget {
+  final ChatMessage message;
+
+  const ChatMessageWidget({super.key, required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    final alignment = message.isUser ? Alignment.centerRight : Alignment.centerLeft;
+    final backgroundColor = message.isUser
+        ? context.myTheme.primaryContainer
+        : context.myTheme.secondaryContainer;
+    final textColor = message.isUser
+        ? context.myTheme.onPrimaryContainer
+        : context.myTheme.onSecondaryContainer;
+
+    return Align(
+      alignment: alignment,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4.0),
+        padding: const EdgeInsets.all(AppThemeConstants.mediumPadding),
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: BorderRadius.circular(AppThemeConstants.mediumBorderRadius),
+        ),
+        child: Text(
+          message.text,
+          style: context.textTheme.bodyLarge?.copyWith(color: textColor),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `ChatMessageWidget` for showing messages in a chat style
- redesign `DreamPage` to behave like a chat interface

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa07558e883228b5d4697b97d64ea