### PR TITLE
Fix Gemini stream parsing

### DIFF
--- a/lib/core/data/clients/gemini/gemini_client.dart
+++ b/lib/core/data/clients/gemini/gemini_client.dart
@@ -17,6 +17,12 @@ class GeminiClient {
     return _dio.post<T>(path, data: data);
   }
 
+  /// Sends a POST request and returns the response body as a stream of lines.
+  ///
+  /// Gemini streaming API returns data as a Server Sent Event (SSE) where each
+  /// event is separated by a new line. To properly handle this format the raw
+  /// byte stream is first decoded using UTF-8 and then split into individual
+  /// lines.
   Stream<String> postStream(String path, {Map<String, dynamic>? data}) async* {
     final response = await _dio.post<ResponseBody>(
       path,
@@ -27,7 +33,7 @@ class GeminiClient {
     final stream = response.data?.stream;
     if (stream == null) return;
 
-    // Aqui está a mudança: decodificação segura da stream UTF-8
-    yield* utf8.decoder.bind(stream);
+    // Decode the UTF-8 bytes and split into lines for SSE parsing.
+    yield* utf8.decoder.bind(stream).transform(const LineSplitter());
   }
 }


### PR DESCRIPTION
## Summary
- improve SSE parsing in `GeminiClient.postStream`
- properly parse streaming lines in `GeminiDatasourceImpl`

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687aa515f1b48322be4e3b882a6b86a1