### PR TITLE
Fix Gemini message streaming

### DIFF
--- a/lib/modules/dream/presentation/dream_page.dart
+++ b/lib/modules/dream/presentation/dream_page.dart
@@ -29,6 +29,7 @@ class _DreamPageState extends State<DreamPage> {
   void dispose() {
     _controller.dispose();
     _scrollController.dispose();
+    _bloc.close();
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- update DreamBloc to emit states from gemini stream via `emit.forEach`
- close DreamBloc when the dream page is disposed to avoid leaks

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa7680a0c832289218d5953d4e5cc