### PR TITLE
Add avatars and dream image generation

### DIFF
--- a/lib/core/di/dependency_injection.config.dart
+++ b/lib/core/di/dependency_injection.config.dart
@@ -34,6 +34,7 @@ import '../../modules/dream/data/repositories/dream_repository_impl.dart'
 import '../../modules/dream/domain/repositories/dream_repository.dart' as _i563;
 import '../../modules/dream/domain/usecases/analyze_dream.dart' as _i357;
 import '../../modules/dream/domain/usecases/get_dreams.dart' as _i1037;
+import '../../modules/dream/domain/usecases/generate_dream_image.dart' as _i1100;
 import '../../modules/dream/presentation/controller/dream_bloc.dart' as _i933;
 import '../data/clients/gemini/gemini_client.dart' as _i969;
 import '../data/clients/http/client_http.dart' as _i777;
@@ -93,6 +94,11 @@ extension GetItInjectableX on _i174.GetIt {
       () =>
           _i1037.GetDreamsUseCase(dreamRepository: gh<_i563.DreamRepository>()),
     );
+    gh.factory<_i1100.GenerateDreamImageUseCase>(
+      () => _i1100.GenerateDreamImageUseCase(
+        dreamRepository: gh<_i563.DreamRepository>(),
+      ),
+    );
     gh.factory<_i51.AutoLoginUseCase>(
       () => _i51.AutoLoginUseCase(authRepository: gh<_i779.AuthRepository>()),
     );
@@ -110,6 +116,7 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i933.DreamBloc(
         analyzeDreamUseCase: gh<_i357.AnalyzeDreamUseCase>(),
         getDreamsUseCase: gh<_i1037.GetDreamsUseCase>(),
+        generateDreamImageUseCase: gh<_i1100.GenerateDreamImageUseCase>(),
       ),
     );
     gh.factory<_i311.AuthBloc>(

--- a/lib/modules/dream/data/datasources/gemini_datasource.dart
+++ b/lib/modules/dream/data/datasources/gemini_datasource.dart
@@ -1,3 +1,5 @@
 abstract class GeminiDatasource {
   Future<String> getMeaning(String dreamText);
+
+  Future<String> createImage(String dreamText);
 }

--- a/lib/modules/dream/data/datasources/gemini_datasource_impl.dart
+++ b/lib/modules/dream/data/datasources/gemini_datasource_impl.dart
@@ -34,4 +34,10 @@ class GeminiDatasourceImpl implements GeminiDatasource {
         json['candidates']?[0]?['content']?['parts']?[0]?['text'] as String?;
     return text ?? '';
   }
+
+  @override
+  Future<String> createImage(String dreamText) async {
+    // TODO: integrate with Gemini API to generate images
+    return 'https://placehold.co/600x400';
+  }
 }

--- a/lib/modules/dream/data/repositories/dream_repository_impl.dart
+++ b/lib/modules/dream/data/repositories/dream_repository_impl.dart
@@ -44,6 +44,18 @@ class DreamRepositoryImpl implements DreamRepository {
   }
 
   @override
+  Future<EitherOf<AppFailure, String>> generateDreamImage(
+    String dreamText,
+  ) async {
+    try {
+      final url = await _gemini.createImage(dreamText);
+      return resolve(url);
+    } catch (e) {
+      return reject(DreamException(e.toString()));
+    }
+  }
+
+  @override
   Future<EitherOf<AppFailure, List<DreamEntity>>> getDreams(
     String userId,
   ) async {

--- a/lib/modules/dream/domain/repositories/dream_repository.dart
+++ b/lib/modules/dream/domain/repositories/dream_repository.dart
@@ -8,5 +8,7 @@ abstract class DreamRepository {
     required String userId,
   });
 
+  Future<EitherOf<AppFailure, String>> generateDreamImage(String dreamText);
+
   Future<EitherOf<AppFailure, List<DreamEntity>>> getDreams(String userId);
 }

--- a/lib/modules/dream/domain/usecases/generate_dream_image.dart
+++ b/lib/modules/dream/domain/usecases/generate_dream_image.dart
@@ -1,0 +1,18 @@
+import 'package:injectable/injectable.dart';
+import 'package:my_dreams/core/domain/entities/either_of.dart';
+import 'package:my_dreams/core/domain/entities/failure.dart';
+import 'package:my_dreams/core/domain/entities/usecase.dart';
+import '../repositories/dream_repository.dart';
+
+@injectable
+class GenerateDreamImageUseCase implements UseCase<String, String> {
+  final DreamRepository _repository;
+
+  GenerateDreamImageUseCase({required DreamRepository dreamRepository})
+      : _repository = dreamRepository;
+
+  @override
+  Future<EitherOf<AppFailure, String>> call(String dreamText) {
+    return _repository.generateDreamImage(dreamText);
+  }
+}

--- a/lib/modules/dream/presentation/controller/dream_states.dart
+++ b/lib/modules/dream/presentation/controller/dream_states.dart
@@ -3,7 +3,8 @@ import '../../domain/entities/dream_entity.dart';
 abstract class DreamStates {
   DreamLoadingState loading() => DreamLoadingState();
   DreamFailureState failure(String message) => DreamFailureState(message);
-  DreamAnalyzedState analyzed(DreamEntity dream) => DreamAnalyzedState(dream);
+  DreamAnalyzedState analyzed(DreamEntity dream, String imageUrl) =>
+      DreamAnalyzedState(dream, imageUrl);
   DreamListLoadedState dreams(List<DreamEntity> list) =>
       DreamListLoadedState(list);
 }
@@ -19,7 +20,9 @@ class DreamFailureState extends DreamStates {
 
 class DreamAnalyzedState extends DreamStates {
   final DreamEntity dream;
-  DreamAnalyzedState(this.dream);
+  final String imageUrl;
+
+  DreamAnalyzedState(this.dream, this.imageUrl);
 }
 
 class DreamListLoadedState extends DreamStates {

--- a/lib/modules/dream/presentation/dream_page.dart
+++ b/lib/modules/dream/presentation/dream_page.dart
@@ -45,15 +45,16 @@ class _DreamPageState extends State<DreamPage> {
     });
   }
 
-  Future<void> _startTypingAnimation(String text) async {
+  Future<void> _startTypingAnimation(String text, String imageUrl) async {
     final words = text.split(' ');
     var buffer = '';
-    setState(() => _messages.add(ChatMessage(text: '', isUser: false)));
+    setState(() =>
+        _messages.add(ChatMessage(text: '', isUser: false, imageUrl: imageUrl)));
     for (final word in words) {
       buffer += buffer.isEmpty ? word : ' $word';
       setState(() {
         _messages[_messages.length - 1] =
-            ChatMessage(text: buffer, isUser: false);
+            ChatMessage(text: buffer, isUser: false, imageUrl: imageUrl);
       });
       _scrollToBottom();
       await Future.delayed(const Duration(milliseconds: 50));
@@ -89,7 +90,7 @@ class _DreamPageState extends State<DreamPage> {
                     setState(() => _isLoading = true);
                   } else if (state is DreamAnalyzedState) {
                     setState(() => _isLoading = false);
-                    _startTypingAnimation(state.dream.answer.value);
+                    _startTypingAnimation(state.dream.answer.value, state.imageUrl);
                   } else if (state is DreamFailureState) {
                     setState(() => _isLoading = false);
                     ScaffoldMessenger.of(

--- a/lib/modules/dream/presentation/widgets/chat_message_widget.dart
+++ b/lib/modules/dream/presentation/widgets/chat_message_widget.dart
@@ -1,12 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:my_dreams/core/constants/constants.dart';
+import 'package:my_dreams/core/domain/entities/app_assets.dart';
 import 'package:my_dreams/shared/themes/app_theme_constants.dart';
 
 class ChatMessage {
   final String text;
   final bool isUser;
+  final String? imageUrl;
 
-  ChatMessage({required this.text, required this.isUser});
+  ChatMessage({
+    required this.text,
+    required this.isUser,
+    this.imageUrl,
+  });
 }
 
 class ChatMessageWidget extends StatelessWidget {
@@ -16,28 +22,53 @@ class ChatMessageWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final alignment = message.isUser ? Alignment.centerRight : Alignment.centerLeft;
-    final backgroundColor = message.isUser
+    final isUser = message.isUser;
+    final backgroundColor = isUser
         ? context.myTheme.primaryContainer
         : context.myTheme.secondaryContainer;
-    final textColor = message.isUser
+    final textColor = isUser
         ? context.myTheme.onPrimaryContainer
         : context.myTheme.onSecondaryContainer;
 
-    return Align(
-      alignment: alignment,
-      child: Container(
-        margin: const EdgeInsets.symmetric(vertical: 4.0),
-        padding: const EdgeInsets.all(AppThemeConstants.mediumPadding),
-        decoration: BoxDecoration(
-          color: backgroundColor,
-          borderRadius: BorderRadius.circular(AppThemeConstants.mediumBorderRadius),
-        ),
-        child: Text(
-          message.text,
-          style: context.textTheme.bodyLarge?.copyWith(color: textColor),
-        ),
+    final avatar = isUser
+        ? CircleAvatar(backgroundImage: const AssetImage(AppAssets.google))
+        : const CircleAvatar(child: Icon(Icons.android));
+
+    final content = Container(
+      margin: const EdgeInsets.symmetric(vertical: 4.0),
+      padding: const EdgeInsets.all(AppThemeConstants.mediumPadding),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(AppThemeConstants.mediumBorderRadius),
       ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            message.text,
+            style: context.textTheme.bodyLarge?.copyWith(color: textColor),
+          ),
+          if (message.imageUrl != null && message.imageUrl!.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 8.0),
+              child: Image.network(
+                message.imageUrl!,
+                errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+              ),
+            ),
+        ],
+      ),
+    );
+
+    return Row(
+      mainAxisAlignment:
+          isUser ? MainAxisAlignment.end : MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (!isUser) avatar,
+        Flexible(child: content),
+        if (isUser) avatar,
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- show user and Gemini avatars in chat
- request dream images from Gemini (placeholder implementation)
- display generated dream images in chat messages
- add GenerateDreamImageUseCase and wire through DI

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b0434ddf48322a4e93b13221537dc