### PR TITLE
Add image support to Dream flow

### DIFF
--- a/lib/core/di/dependency_injection.config.dart
+++ b/lib/core/di/dependency_injection.config.dart
@@ -99,7 +99,6 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i933.DreamBloc(
         analyzeDreamUseCase: gh<_i357.AnalyzeDreamUseCase>(),
         getDreamsUseCase: gh<_i1037.GetDreamsUseCase>(),
-        generateDreamImageUseCase: gh<_i708.GenerateDreamImageUseCase>(),
       ),
     );
     gh.factory<_i779.AuthRepository>(

--- a/lib/modules/dream/data/adapters/dream_adapter.dart
+++ b/lib/modules/dream/data/adapters/dream_adapter.dart
@@ -7,6 +7,7 @@ class DreamAdapter {
       userId: map['user_id'] as String,
       message: map['description'] as String,
       answer: map['response_ai'] as String,
+      imageUrl: map['image_url'] as String? ?? '',
       createdAt: DateTime.parse(map['created_at'] as String),
     );
   }
@@ -16,6 +17,7 @@ class DreamAdapter {
       'user_id': dream.userId.value,
       'description': dream.message.value,
       'response_ai': dream.answer.value,
+      'image_url': dream.imageUrl.value,
     };
   }
 }

--- a/lib/modules/dream/data/repositories/dream_repository_impl.dart
+++ b/lib/modules/dream/data/repositories/dream_repository_impl.dart
@@ -26,12 +26,14 @@ class DreamRepositoryImpl implements DreamRepository {
   }) async {
     try {
       final answer = await _gemini.getMeaning(dreamText);
+      final imageUrl = await _gemini.createImage(answer);
 
       final dream = DreamEntity(
         id: 0,
         userId: userId,
         message: dreamText,
         answer: answer,
+        imageUrl: imageUrl,
         createdAt: DateTime.now(),
       );
 

--- a/lib/modules/dream/domain/entities/dream_entity.dart
+++ b/lib/modules/dream/domain/entities/dream_entity.dart
@@ -7,6 +7,7 @@ class DreamEntity extends BaseEntity {
   TextVO userId;
   TextVO message;
   TextVO answer;
+  TextVO imageUrl;
   DateTimeVO createdAt;
 
   DreamEntity({
@@ -14,10 +15,12 @@ class DreamEntity extends BaseEntity {
     required String userId,
     required String message,
     required String answer,
+    required String imageUrl,
     required DateTime createdAt,
   })  : userId = TextVO(userId),
         message = TextVO(message),
         answer = TextVO(answer),
+        imageUrl = TextVO(imageUrl),
         createdAt = DateTimeVO(createdAt),
         super(id: IntVO(id));
 }

--- a/lib/modules/dream/presentation/controller/dream_bloc.dart
+++ b/lib/modules/dream/presentation/controller/dream_bloc.dart
@@ -2,7 +2,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 
 import '../../domain/usecases/analyze_dream.dart';
-import '../../domain/usecases/generate_dream_image.dart';
 import '../../domain/usecases/get_dreams.dart';
 import 'dream_events.dart';
 import 'dream_states.dart';
@@ -11,15 +10,12 @@ import 'dream_states.dart';
 class DreamBloc extends Bloc<DreamEvents, DreamStates> {
   final AnalyzeDreamUseCase _analyzeDream;
   final GetDreamsUseCase _getDreams;
-  final GenerateDreamImageUseCase _generateImage;
 
   DreamBloc({
     required AnalyzeDreamUseCase analyzeDreamUseCase,
     required GetDreamsUseCase getDreamsUseCase,
-    required GenerateDreamImageUseCase generateDreamImageUseCase,
   }) : _analyzeDream = analyzeDreamUseCase,
        _getDreams = getDreamsUseCase,
-       _generateImage = generateDreamImageUseCase,
        super(DreamInitialState()) {
     on<SendDreamEvent>(_onSendDream);
     on<GetDreamsEvent>(_onGetDreams);
@@ -35,14 +31,10 @@ class DreamBloc extends Bloc<DreamEvents, DreamStates> {
       AnalyzeDreamParams(dreamText: event.dreamText, userId: event.userId),
     );
 
-    result.get((failure) => emit(state.failure(failure.message)), (
-      dream,
-    ) async {
-      final imageResult = await _generateImage(dream.answer.value);
-      String imageUrl = '';
-      imageResult.get((_) {}, (url) => imageUrl = url);
-      return emit(state.analyzed(dream, imageUrl));
-    });
+    result.get(
+      (failure) => emit(state.failure(failure.message)),
+      (dream) => emit(state.analyzed(dream, dream.imageUrl.value)),
+    );
   }
 
   Future<void> _onGetDreams(


### PR DESCRIPTION
## Summary
- extend `DreamEntity` with `imageUrl`
- map `image_url` in `DreamAdapter`
- fetch image inside `DreamRepositoryImpl.analyzeDream`
- simplify `DreamBloc` by removing `GenerateDreamImageUseCase`
- adjust DI to match new `DreamBloc` constructor

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687b0c1234d08322b9da66a61e5c7c43