### PR TITLE
Improve text input and dream listing

### DIFF
--- a/lib/core/data/clients/supabase/supabase_client_impl.dart
+++ b/lib/core/data/clients/supabase/supabase_client_impl.dart
@@ -58,25 +58,26 @@ class SupabaseClientImpl implements ISupabaseClient {
     Map<String, dynamic> filters = const {},
   }) async {
     dynamic data;
+    final selectedColumns = columns.trim() == '*' ? '*' : columns;
 
     if (orderBy == null || orderBy.isEmpty) {
       if (filters.isNotEmpty) {
         data = await _client
             .from(table)
-            .select(columns)
+            .select(selectedColumns)
             .eq(filters.keys.first, filters.values.first);
       } else {
-        data = await _client.from(table).select(columns);
+        data = await _client.from(table).select(selectedColumns);
       }
     } else {
       if (filters.isNotEmpty) {
         data = await _client
             .from(table)
-            .select(columns)
+            .select(selectedColumns)
             .eq(filters.keys.first, filters.values.first)
             .order(orderBy);
       } else {
-        data = await _client.from(table).select(columns).order(orderBy);
+        data = await _client.from(table).select(selectedColumns).order(orderBy);
       }
     }
 

--- a/lib/modules/dream/presentation/dream_page.dart
+++ b/lib/modules/dream/presentation/dream_page.dart
@@ -133,6 +133,8 @@ class _DreamPageState extends State<DreamPage> {
                     child: AppTextFormField(
                       controller: _controller,
                       readOnly: _isLoading,
+                      textArea: true,
+                      maxLines: 5,
                       hint: !_isLoading
                           ? 'Descreva seu sonho'
                           : 'Analisando...',

--- a/lib/modules/home/presentation/home_page.dart
+++ b/lib/modules/home/presentation/home_page.dart
@@ -19,6 +19,7 @@ import '../../../shared/themes/app_theme_constants.dart';
 import '../../dream/presentation/controller/dream_bloc.dart';
 import '../../dream/presentation/controller/dream_events.dart';
 import '../../dream/presentation/controller/dream_states.dart';
+import 'widgets/dream_card_widget.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -184,15 +185,13 @@ class _HomePageState extends State<HomePage> {
                           child: Text('Nenhum sonho registrado'),
                         );
                       }
-                      return ListView.builder(
+                      return ListView.separated(
                         itemCount: state.dreamsList.length,
+                        separatorBuilder: (_, __) => const SpacerHeight(),
                         itemBuilder: (context, index) {
                           final dream = state.dreamsList[index];
 
-                          return ListTile(
-                            title: Text(dream.message.value),
-                            subtitle: Text(dream.answer.value),
-                          );
+                          return DreamCardWidget(dream: dream);
                         },
                       );
                     }

--- a/lib/modules/home/presentation/widgets/dream_card_widget.dart
+++ b/lib/modules/home/presentation/widgets/dream_card_widget.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:my_dreams/core/constants/constants.dart';
+import 'package:my_dreams/modules/dream/domain/entities/dream_entity.dart';
+import 'package:my_dreams/shared/themes/app_theme_constants.dart';
+
+class DreamCardWidget extends StatelessWidget {
+  final DreamEntity dream;
+
+  const DreamCardWidget({super.key, required this.dream});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: context.myTheme.primaryContainer,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(
+          AppThemeConstants.mediumBorderRadius,
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(AppThemeConstants.mediumPadding),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              dream.message.value,
+              style: context.textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 8),
+            Text(dream.answer.value),
+            if (dream.imageUrl.value.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 8.0),
+                child: Image.network(
+                  dream.imageUrl.value,
+                  errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/components/text_form_field.dart
+++ b/lib/shared/components/text_form_field.dart
@@ -23,6 +23,8 @@ class AppTextFormField extends StatefulWidget {
   TextInputAction? textInputAction;
   bool readOnly;
   Widget? suffixIcon;
+  int? maxLines;
+  bool expands;
 
   AppTextFormField({
     super.key,
@@ -43,6 +45,8 @@ class AppTextFormField extends StatefulWidget {
     this.textInputAction,
     this.readOnly = false,
     this.suffixIcon,
+    this.maxLines,
+    this.expands = false,
   });
 
   @override
@@ -73,7 +77,10 @@ class _AppTextFormFieldState extends State<AppTextFormField> {
       obscureText: _hideInput,
       controller: widget.controller,
       cursorColor: Colors.white.withAlpha(150),
-      maxLines: widget.textArea ? null : 1,
+      expands: widget.expands,
+      maxLines: widget.expands
+          ? null
+          : widget.maxLines ?? (widget.textArea ? null : 1),
       style: context.textTheme.bodyLarge?.copyWith(
         color: widget.borderColor ?? Colors.white,
         decorationColor: Colors.transparent,


### PR DESCRIPTION
## Summary
- support `maxLines` and `expands` on `AppTextFormField`
- allow multiline text on dream page
- show dreams on home page using a new `DreamCardWidget`
- handle selecting all columns in Supabase client

## Testing
- `dart format lib/shared/components/text_form_field.dart lib/modules/dream/presentation/dream_page.dart lib/modules/home/presentation/home_page.dart lib/modules/home/presentation/widgets/dream_card_widget.dart lib/core/data/clients/supabase/supabase_client_impl.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fbd1506488322b1f4d24e1ca7a4fb