### PR TITLE
Improve Dream Card styling

### DIFF
--- a/lib/modules/home/presentation/widgets/dream_card_widget.dart
+++ b/lib/modules/home/presentation/widgets/dream_card_widget.dart
@@ -3,6 +3,7 @@ import 'package:my_dreams/core/constants/constants.dart';
 import 'package:my_dreams/modules/dream/domain/entities/dream_entity.dart';
 import 'package:my_dreams/modules/dream/presentation/widgets/chat_message_widget.dart';
 import 'package:my_dreams/shared/themes/app_theme_constants.dart';
+import 'package:my_dreams/shared/utils/formatters.dart';
 
 class DreamCardWidget extends StatelessWidget {
   final DreamEntity dream;
@@ -11,12 +12,15 @@ class DreamCardWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final borderColor = context.myTheme.outline;
+
     return Card(
       color: context.myTheme.surface,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(
           AppThemeConstants.mediumBorderRadius,
         ),
+        side: BorderSide(color: borderColor),
       ),
       child: Padding(
         padding: const EdgeInsets.all(AppThemeConstants.mediumPadding),
@@ -36,6 +40,18 @@ class DreamCardWidget extends StatelessWidget {
                     : null,
               ),
             ),
+            if (dream.createdAt != null)
+              Padding(
+                padding:
+                    const EdgeInsets.only(top: AppThemeConstants.halfPadding),
+                child: Text(
+                  dream.createdAt!.value.diaMesAnoHora(),
+                  style: context.textTheme.bodySmall?.copyWith(
+                    color: context.myTheme.onSurfaceVariant,
+                  ),
+                  textAlign: TextAlign.end,
+                ),
+              ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- style DreamCardWidget with a visible border
- display created date on dream cards

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fcc2984c483228e3f8de89d069b42