### PR TITLE
Implement dream chat view and tap navigation

### DIFF
--- a/lib/core/domain/entities/named_routes.dart
+++ b/lib/core/domain/entities/named_routes.dart
@@ -3,6 +3,7 @@ enum NamedRoutes {
   auth('/auth'),
   home('/home'),
   dream('/dream'),
+  dreamChat('/dream-chat'),
   planting('/planting'),
   myPlantings('/my-plantings'),
   impact('/impact');

--- a/lib/core/routes/app_routes.dart
+++ b/lib/core/routes/app_routes.dart
@@ -3,6 +3,8 @@ import 'package:my_dreams/modules/auth/presentation/auth_page.dart';
 import 'package:my_dreams/modules/splash/presentation/splash_page.dart';
 import 'package:my_dreams/modules/home/presentation/home_page.dart';
 import 'package:my_dreams/modules/dream/presentation/dream_page.dart';
+import 'package:my_dreams/modules/dream/presentation/dream_chat_page.dart';
+import 'package:my_dreams/modules/dream/domain/entities/dream_entity.dart';
 
 import '../domain/entities/named_routes.dart';
 import 'domain/entities/custom_transition.dart';
@@ -21,7 +23,12 @@ class CustomNavigator {
       NamedRoutes.dream.route: (BuildContext context) => const DreamPage(),
     };
 
-    final WidgetBuilder? builder = appRoutes[settings.name];
+    WidgetBuilder? builder = appRoutes[settings.name];
+
+    if (settings.name == NamedRoutes.dreamChat.route) {
+      final dream = settings.arguments as DreamEntity;
+      builder = (BuildContext context) => DreamChatPage(dream: dream);
+    }
 
     if (builder != null) {
       final CustomTransition customTransition = generateAnimation(settings);

--- a/lib/modules/dream/presentation/dream_chat_page.dart
+++ b/lib/modules/dream/presentation/dream_chat_page.dart
@@ -5,25 +5,18 @@ import 'package:my_dreams/modules/dream/presentation/widgets/chat_message_widget
 import 'package:my_dreams/shared/themes/app_theme_constants.dart';
 import 'package:my_dreams/shared/utils/formatters.dart';
 
-class DreamCardWidget extends StatelessWidget {
+class DreamChatPage extends StatelessWidget {
   final DreamEntity dream;
 
-  const DreamCardWidget({super.key, required this.dream});
+  const DreamChatPage({super.key, required this.dream});
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      color: context.myTheme.surface,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(
-          AppThemeConstants.mediumBorderRadius,
-        ),
-        side: BorderSide(color: context.myTheme.primary),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(AppThemeConstants.mediumPadding),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sonho')),
+      body: Padding(
+        padding: const EdgeInsets.all(AppThemeConstants.padding),
+        child: ListView(
           children: [
             if (dream.createdAt != null) ...[
               Row(
@@ -43,11 +36,19 @@ class DreamCardWidget extends StatelessWidget {
                   ),
                 ],
               ),
-
               Divider(color: context.myTheme.primary),
             ],
             ChatMessageWidget(
               message: ChatMessage(text: dream.message.value, isUser: true),
+            ),
+            const SizedBox(height: 8),
+            ChatMessageWidget(
+              message: ChatMessage(
+                text: dream.answer.value,
+                isUser: false,
+                imageUrl:
+                    dream.imageUrl.value.isNotEmpty ? dream.imageUrl.value : null,
+              ),
             ),
           ],
         ),

--- a/lib/modules/home/presentation/home_page.dart
+++ b/lib/modules/home/presentation/home_page.dart
@@ -191,7 +191,14 @@ class _HomePageState extends State<HomePage> {
                         itemBuilder: (context, index) {
                           final dream = state.dreamsList[index];
 
-                          return DreamCardWidget(dream: dream);
+                          return InkWell(
+                            onTap: () => Navigator.pushNamed(
+                              context,
+                              NamedRoutes.dreamChat.route,
+                              arguments: dream,
+                            ),
+                            child: DreamCardWidget(dream: dream),
+                          );
                         },
                       );
                     }


### PR DESCRIPTION
## Summary
- add new route to NamedRoutes
- handle new route in `CustomNavigator` using route arguments
- show only the question in `DreamCardWidget`
- open new `DreamChatPage` when tapping a dream card
- create `DreamChatPage` to display question and answer

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff6024c848322a79962b3b0218bf3