### PR TITLE
Implement conversation summary updates

### DIFF
--- a/lib/modules/chat/data/datasources/chat_ai_datasource.dart
+++ b/lib/modules/chat/data/datasources/chat_ai_datasource.dart
@@ -1,3 +1,8 @@
 abstract class ChatAiDatasource {
-  Future<String> generateAnswer(String prompt);
+  Future<String> generateAnswer(
+    String prompt, {
+    String? summary,
+  });
+
+  Future<String> generateConversationSummary(String context);
 }

--- a/lib/modules/chat/data/datasources/chat_ai_datasource_impl.dart
+++ b/lib/modules/chat/data/datasources/chat_ai_datasource_impl.dart
@@ -10,14 +10,45 @@ class ChatAiDatasourceImpl implements ChatAiDatasource {
   ChatAiDatasourceImpl({required GeminiClient client}) : _client = client;
 
   @override
-  Future<String> generateAnswer(String prompt) async {
+  Future<String> generateAnswer(
+    String prompt, {
+    String? summary,
+  }) async {
+    final message = summary != null && summary.isNotEmpty
+        ? 'Resumo do contexto da conversa: $summary\nUsu\u00E1rio: $prompt'
+        : 'Fale o significado do meu sonho, fa\u00E7a um pequeno resumo: $prompt';
+
     final data = {
       'contents': [
         {
           'parts': [
             {
-              'text':
-                  'Fale o significado do meu sonho, faça um pequeno resumo: $prompt',
+              'text': message,
+            },
+          ],
+        },
+      ],
+    };
+
+    final response = await _client.post(
+      '/models/gemini-2.0-flash:generateContent',
+      data: data,
+    );
+
+    final json = response.data as Map<String, dynamic>;
+    final text =
+        json['candidates']?[0]?['content']?['parts']?[0]?['text'] as String?;
+    return text ?? '';
+  }
+
+  @override
+  Future<String> generateConversationSummary(String context) async {
+    final data = {
+      'contents': [
+        {
+          'parts': [
+            {
+              'text': 'Resuma brevemente a conversa: $context',
             },
           ],
         },


### PR DESCRIPTION
## Summary
- allow AI datasource to receive previous summary context and generate conversation summary
- update Supabase datasource to use and update conversation summaries

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688035911b708322adfcde5ae4b3e390