### PR TITLE
Fix conversation updates after sending messages

### DIFF
--- a/lib/modules/chat/presentation/controller/chat_bloc.dart
+++ b/lib/modules/chat/presentation/controller/chat_bloc.dart
@@ -64,9 +64,20 @@ class ChatBloc extends Bloc<ChatEvents, ChatStates> {
         content: event.content,
       ),
     );
-    result.get(
-      (failure) => emit(state.failure(failure.message)),
-      (list) => emit(state.messages(list)),
+
+    await result.get(
+      (failure) async => emit(state.failure(failure.message)),
+      (list) async {
+        final convId = list.first.conversationId.value;
+        final messagesResult = await _getMessages(
+          GetMessagesParams(conversationId: convId),
+        );
+
+        messagesResult.get(
+          (failure) => emit(state.failure(failure.message)),
+          (messages) => emit(state.messages(messages)),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- ensure entire conversation is loaded after sending a message

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_68803a6bdd6c83229689530f80a9f50b