### PR TITLE
Add thinking indicator on chat

### DIFF
--- a/lib/modules/chat/presentation/chat_page.dart
+++ b/lib/modules/chat/presentation/chat_page.dart
@@ -10,6 +10,7 @@ import 'package:my_dreams/shared/themes/app_theme_constants.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
 
 import '../../dream/presentation/widgets/chat_message_widget.dart';
+import 'widgets/thinking_message_widget.dart';
 import 'controller/chat_bloc.dart';
 import 'controller/chat_events.dart';
 import 'controller/chat_states.dart';
@@ -96,6 +97,7 @@ class _ChatPageState extends State<ChatPage> {
                   listener: (context, state) {
                     if (state is ChatLoadingState) {
                       setState(() => _isLoading = true);
+                      _scrollToBottom();
                     } else if (state is ChatLoadedMessagesState) {
                       setState(() => _isLoading = false);
                       _messages
@@ -125,12 +127,14 @@ class _ChatPageState extends State<ChatPage> {
                   },
                   child: SuperListView.builder(
                     controller: _scrollController,
-                    itemCount: _messages.length,
+                    itemCount: _messages.length + (_isLoading ? 1 : 0),
                     itemBuilder: (context, index) {
+                      if (index >= _messages.length) {
+                        return const ThinkingMessageWidget();
+                      }
                       final message = _messages[index];
                       return ChatMessageWidget(
                         message: message,
-                        isLoading: _isLoading,
                       );
                     },
                   ),

--- a/lib/modules/chat/presentation/widgets/thinking_message_widget.dart
+++ b/lib/modules/chat/presentation/widgets/thinking_message_widget.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:my_dreams/core/constants/constants.dart';
+import 'package:my_dreams/shared/themes/app_theme_constants.dart';
+
+class ThinkingMessageWidget extends StatelessWidget {
+  const ThinkingMessageWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final backgroundColor = context.myTheme.secondaryContainer;
+    final textColor = context.myTheme.onSecondaryContainer;
+
+    final text = Text(
+      'Pensando...',
+      style: context.textTheme.bodyLarge?.copyWith(color: textColor),
+    );
+
+    final bubble = Container(
+      margin: const EdgeInsets.symmetric(vertical: 4.0),
+      padding: const EdgeInsets.all(AppThemeConstants.mediumPadding),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(
+          AppThemeConstants.mediumBorderRadius,
+        ),
+      ),
+      child: text,
+    )
+        .animate(onPlay: (controller) => controller.repeat(reverse: true))
+        .fade(duration: const Duration(milliseconds: 800))
+        .scale(begin: 0.95, end: 1.05, duration: const Duration(milliseconds: 800));
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.only(top: 5),
+          child: CircleAvatar(child: Icon(Icons.android)),
+        ),
+        const SizedBox(width: 10),
+        Flexible(child: bubble),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show a thinking animation while waiting for AI responses
- introduce `ThinkingMessageWidget` with fade and scale effects

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880ed83afb0832293a89c83da67c533