### PR TITLE
Add tarot card option parsing

### DIFF
--- a/lib/modules/chat/domain/entities/tarot_card_entity.dart
+++ b/lib/modules/chat/domain/entities/tarot_card_entity.dart
@@ -1,0 +1,6 @@
+class TarotCardEntity {
+  final String title;
+  final String description;
+
+  const TarotCardEntity({required this.title, required this.description});
+}

--- a/lib/modules/chat/domain/usecases/parse_tarot_message.dart
+++ b/lib/modules/chat/domain/usecases/parse_tarot_message.dart
@@ -1,0 +1,17 @@
+import 'package:my_dreams/modules/chat/domain/entities/tarot_card_entity.dart';
+
+class ParseTarotMessageUseCase {
+  List<TarotCardEntity> call(String text) {
+    final regex = RegExp(
+      r'(Carta\s*[123])\s*:\s*(.*?)(?=(Carta\s*[123]\s*:)|\$)',
+      caseSensitive: false,
+      dotAll: true,
+    );
+
+    return regex.allMatches(text).map((match) {
+      final title = match.group(1)!.trim();
+      final description = match.group(2)!.trim();
+      return TarotCardEntity(title: title, description: description);
+    }).toList();
+  }
+}

--- a/lib/modules/chat/presentation/widgets/tarot_options_widget.dart
+++ b/lib/modules/chat/presentation/widgets/tarot_options_widget.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:my_dreams/core/constants/constants.dart';
+import 'package:my_dreams/shared/components/custom_button.dart';
+import '../../domain/entities/tarot_card_entity.dart';
+
+class TarotOptionsWidget extends StatelessWidget {
+  final List<TarotCardEntity> cards;
+  final void Function(TarotCardEntity) onSelected;
+
+  const TarotOptionsWidget({
+    super.key,
+    required this.cards,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      children: cards
+          .map(
+            (card) => AppCustomButton(
+              backgroundColor: context.myTheme.primaryContainer,
+              onPressed: () => onSelected(card),
+              label: Text(card.title),
+            ),
+          )
+          .toList(),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add entity for Tarot card
- add use case to parse tarot messages
- show tarot options in chat with new widget
- send card choice back to AI

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_68810f7aa3388322a1e9f58a489b401c