### PR TITLE
Fix tarot parsing regex

### DIFF
--- a/lib/modules/chat/domain/usecases/parse_tarot_message.dart
+++ b/lib/modules/chat/domain/usecases/parse_tarot_message.dart
@@ -5,7 +5,7 @@ import 'package:my_dreams/modules/chat/domain/entities/tarot_card_entity.dart';
 class ParseTarotMessageUseCase {
   List<TarotCardEntity> call(String text) {
     final regex = RegExp(
-      r'(Carta\s*[123])\s*:\s*(.*?)(?=(Carta\s*[123]\s*:)|\$)',
+      r'(Carta\s*[1-5])\s*:\s*(.*?)(?=(Carta\s*[1-5]\s*:)|\$)',
       caseSensitive: false,
       dotAll: true,
     );


### PR DESCRIPTION
## Summary
- update regex for tarot message parsing to allow up to 5 cards

## Testing
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68811ae9eff083228ba0dec0e28af1a3