### PR TITLE
Fix tarot regex to accept hyphenated responses

### DIFF
--- a/lib/modules/chat/domain/usecases/parse_tarot_message.dart
+++ b/lib/modules/chat/domain/usecases/parse_tarot_message.dart
@@ -5,7 +5,7 @@ import 'package:my_dreams/modules/chat/domain/entities/tarot_card_entity.dart';
 class ParseTarotMessageUseCase {
   List<TarotCardEntity> call(String text) {
     final regex = RegExp(
-      r'(Carta\s*[1-5])\s*:\s*(.*?)(?=(Carta\s*[1-5]\s*:)|\$)',
+      r'(Carta\s*[1-5])\s*[:\-–—]\s*(.*?)(?=(Carta\s*[1-5]\s*[:\-–—])|\$)',
       caseSensitive: false,
       dotAll: true,
     );


### PR DESCRIPTION
## Summary
- update parse regex for tarot cards to handle `:` or `-` separators

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68811da4848083229a4cf5413a006e2a