### PR TITLE
Add ChangeNotifier to services

### DIFF
--- a/lib/core/di/dependency_injection.config.dart
+++ b/lib/core/di/dependency_injection.config.dart
@@ -69,8 +69,8 @@ extension GetItInjectableX on _i174.GetIt {
     gh.factory<_i841.ParseTarotMessageUseCase>(
       () => _i841.ParseTarotMessageUseCase(),
     );
-    gh.factory<_i655.AdsService>(() => _i655.AdsService());
-    gh.factory<_i17.PurchaseService>(() => _i17.PurchaseService());
+    gh.singleton<_i655.AdsService>(() => _i655.AdsService());
+    gh.singleton<_i17.PurchaseService>(() => _i17.PurchaseService());
     gh.singleton<_i86.ISupabaseClient>(() => _i788.SupabaseClientImpl());
     gh.factory<_i824.ILocalStorage>(() => _i755.SharedPreferencesService());
     gh.factory<_i123.GeminiClient>(

--- a/lib/modules/chat/presentation/chat_page.dart
+++ b/lib/modules/chat/presentation/chat_page.dart
@@ -39,12 +39,17 @@ class _ChatPageState extends State<ChatPage> {
       getIt<ParseTarotMessageUseCase>();
   final AdsService _adsService = getIt<AdsService>();
   final PurchaseService _purchase = getIt<PurchaseService>();
+  void _update() {
+    if (mounted) setState(() {});
+  }
   bool _isLoading = false;
   String? _currentConversationId;
 
   @override
   void initState() {
     super.initState();
+    _adsService.addListener(_update);
+    _purchase.addListener(_update);
     _currentConversationId = widget.conversationId;
     if (_currentConversationId != null) {
       _bloc.add(LoadMessagesEvent(conversationId: _currentConversationId!));
@@ -53,6 +58,8 @@ class _ChatPageState extends State<ChatPage> {
 
   @override
   void dispose() {
+    _adsService.removeListener(_update);
+    _purchase.removeListener(_update);
     _controller.dispose();
     _scrollController.dispose();
     _bloc.close();

--- a/lib/modules/chat/presentation/conversation_list_page.dart
+++ b/lib/modules/chat/presentation/conversation_list_page.dart
@@ -37,6 +37,9 @@ class _HomePageState extends State<HomePage> {
   final ChatBloc _chatBloc = getIt<ChatBloc>();
   final AdsService _adsService = getIt<AdsService>();
   final PurchaseService _purchase = getIt<PurchaseService>();
+  void _update() {
+    if (mounted) setState(() {});
+  }
 
   StreamSubscription<AuthStates>? _authSubscription;
 
@@ -69,6 +72,8 @@ class _HomePageState extends State<HomePage> {
     super.initState();
 
     _listenAuthStates();
+    _adsService.addListener(_update);
+    _purchase.addListener(_update);
     final user = _user;
     if (user != null) {
       _chatBloc.add(LoadConversationsEvent(userId: user.id.value));
@@ -77,6 +82,8 @@ class _HomePageState extends State<HomePage> {
 
   @override
   void dispose() {
+    _adsService.removeListener(_update);
+    _purchase.removeListener(_update);
     _authSubscription?.cancel();
 
     super.dispose();

--- a/lib/shared/services/ads_service.dart
+++ b/lib/shared/services/ads_service.dart
@@ -1,8 +1,9 @@
+import 'package:flutter/foundation.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:injectable/injectable.dart';
 
-@injectable
-class AdsService {
+@singleton
+class AdsService extends ChangeNotifier {
   BannerAd? topBanner;
   BannerAd? bottomBanner;
   InterstitialAd? _interstitial;
@@ -14,6 +15,8 @@ class AdsService {
   }
 
   Future<void> _loadBanners() async {
+    topBanner?.dispose();
+    bottomBanner?.dispose();
     topBanner = BannerAd(
       size: AdSize.banner,
       adUnitId: 'ca-app-pub-1898798427054986/9646986739',
@@ -31,6 +34,7 @@ class AdsService {
     );
 
     await bottomBanner?.load();
+    notifyListeners();
   }
 
   Future<void> loadInterstitial() async {
@@ -38,7 +42,10 @@ class AdsService {
       adUnitId: 'ca-app-pub-1898798427054986/1528823562',
       request: const AdRequest(),
       adLoadCallback: InterstitialAdLoadCallback(
-        onAdLoaded: (ad) => _interstitial = ad,
+        onAdLoaded: (ad) {
+          _interstitial = ad;
+          notifyListeners();
+        },
         onAdFailedToLoad: (error) => _interstitial = null,
       ),
     );

--- a/lib/shared/services/purchase_service.dart
+++ b/lib/shared/services/purchase_service.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:in_app_purchase/in_app_purchase.dart';
 import 'package:injectable/injectable.dart';
 import 'package:my_dreams/core/domain/entities/app_global.dart';
 import 'package:my_dreams/core/domain/entities/subscription_plan.dart';
 
-@injectable
-class PurchaseService {
+@singleton
+class PurchaseService extends ChangeNotifier {
   final InAppPurchase _iap = InAppPurchase.instance;
   late StreamSubscription<List<PurchaseDetails>> _subscription;
 
@@ -27,10 +28,13 @@ class PurchaseService {
           purchase.status == PurchaseStatus.restored) {
         if (purchase.productID == weeklyId) {
           AppGlobal.instance.setPlan(SubscriptionPlan.weekly);
+          notifyListeners();
         } else if (purchase.productID == monthlyId) {
           AppGlobal.instance.setPlan(SubscriptionPlan.monthly);
+          notifyListeners();
         } else if (purchase.productID == annualId) {
           AppGlobal.instance.setPlan(SubscriptionPlan.annual);
+          notifyListeners();
         }
       }
     }


### PR DESCRIPTION
## Summary
- make `AdsService` and `PurchaseService` extend `ChangeNotifier`
- register both services as singletons in DI
- listen for updates from these services in chat pages

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68812cbd13cc8322b90f4d2bd531a94a