### PR TITLE
Add localization support

### DIFF
--- a/assets/i18n/en_US.yaml
+++ b/assets/i18n/en_US.yaml
@@ -1,0 +1,35 @@
+app:
+  name: My Dreams AI
+common:
+  error: Error
+  oops: Oops...
+  cancel: Cancel
+splash:
+  screen:
+    title: Explore your dreams with us
+auth:
+  googleButton: Sign in with Google
+  screen:
+    title: Record the dreams you had here
+    subtitle: Discover meanings and share
+    footer: Your dreams, our universe.
+chat:
+  screen:
+    title: Conversation
+  generateTarot: Generate Tarot cards
+  input:
+    hint: Type your message
+    sending: Sending...
+  limit:
+    title: Limit reached
+    message: Your subscription allows sending only {limit} message(s).
+conversation:
+  logout:
+    title: Logout
+    message: Do you really want to exit the app?
+    cancel: Cancel
+    confirm: Logout
+  empty: No meaning found
+  new: New Meaning
+dream:
+  dateLabel: 'Date: '

--- a/assets/i18n/pt_BR.yaml
+++ b/assets/i18n/pt_BR.yaml
@@ -1,305 +1,35 @@
+app:
+  name: My Dreams AI
 common:
-  edit: Editar
-  delete: Excluir
+  error: Erro
+  oops: Ops...
   cancel: Cancelar
-  save: Salvar
-  pricemy: Pricemy
-  close: Fechar
-
-pricemy:
-  slogan:
-    time: CRONOMETRE
-    manage: GERENCIE
-    conquer: CONQUISTE
-
-http:
-  error:
-    genericMessage: Erro no servidor
-    connectionError: Erro de conexão. Verifique sua internet
-    serverError: Erro no servidor
-
-server:
-  noValidToken: Token inválido
-  noValidCredentials: Credenciais inválidas
-  loginError: Erro ao entrar
-  invalidToken: Token inválido
-  blockedUser: Usuário bloqueado
-  expiredToken: Token expirado
-  generalAuthError: Erro de autenticação
-  upsertError: Erro ao salvar
-  userInfoHasNotProvided: Informações do usuário não fornecidas
-  noUserData: Não foi possível obter os dados do usuário
-  invalidInput: Entrada inválida
-  deleteError: Erro ao deletar
-  listError: Erro ao listar
-  notFound: Não encontrado
-  getError: Erro ao carregar
-
-token:
-  error:
-    invalidToken: Token inválido
-
+splash:
+  screen:
+    title: Explore seus sonhos conosco
 auth:
-  error:
-    invalidCredentials: Credenciais inválidas
-    noUserData: Não foi possível obter os dados do usuário
-    message: Erro ao autenticar usuário
-    invalidEmail: Email inválido
-    emailAlreadyInUse: Email já está em uso
-    invalidPassword: Credenciais inválidas
-    userNotFound: Usuário não encontrado
-    loginFailed: Falha ao entrar
-    logoutFailed: Falha ao sair
-    registerFailed: Falha ao registrar
-    emailNotVerified: Email não verificado
-    autoLoginFailed: Erro ao entrar automaticamente
-
-  success:
-    registered: Registrado com sucesso
-    verifyEmail: Verifique seu email
-
+  googleButton: Entrar com o Google
   screen:
-    forgotPassword: Esqueci minha senha
-    emailSentMessage: Se o email informado corresponder a um usuário existente, estaremos enviando um email com instruções para recuperar sua conta
-    resendActivationEmail: Reenviar email de ativação
-    byUsingPricemy: Ao usar o Pricemy, você concorda com nossos
-    terms: Termos de uso
-
-payments:
-  error:
-    cacheFailed: Falha ao armazenar pagamentos localmente
-    deleteFailed: Falha ao deletar pagamento
-    upsertLocalFailure: Falha ao armazenar pagamento localmente
-    getFromProjectFailed: Falha ao recuperar pagamentos do projeto
-    getUnsyncedFailed: Falha ao recuperar pagamentos não sincronizados
-    remoteDeleteFailed: Falha ao deletar pagamento no servidor
-    remoteUpsertFailed: Falha ao salvar pagamento no servidor
-    remoteGetFailed: Falha ao recuperar pagamentos do servidor
-    syncFailed: Falha ao sincronizar pagamentos
-    upsertFailed: Falha ao enviar dados do pagamento
-    getFailed: Falha ao coletar pagamentos
-    invalidValue: Valor inválido
-    invalidDate: Data inválida
-
+    title: Registre aqui os sonhos que você teve
+    subtitle: Descubra significados e compartilhe
+    footer: Seus sonhos, nosso universo.
+chat:
   screen:
-    value: Valor
-    valueHint: R$ 1.000,00
-    date: Data
-    dateHint: Ex.01/01/2020
-    deletePayment: Excluir pagamento
-    deletePaymentConfirmationText: Tem certeza que deseja excluir este pagamento?
-    historicalPayments: Histórico
-    noPayments: Ainda não há pagamentos
-    addPayment: Adicionar pagamento
-
-projects:
-
-  error:
-    cacheProjectsFailed: Erro ao carregar projetos
-    getProjectsFailed: Erro ao carregar projetos
-    upsertProjectFailed: Erro ao salvar projeto
-    getUnsyncProjectsFailed: Erro ao carregar projetos não sincronizados
-    deleteProjectFailed: Erro ao excluir projeto
-    synchronizeProjectsFailed: Erro ao sincronizar projetos com o servidor
-    dateEndAfterBegin: Data final deve ser maior que a inicial
-    dateBeginMustBeBeforeToday: Data inicial deve ser anterior à atual
-
-  screen:
-    actives: ATIVOS
-    yourProjects: Seus projetos
-    empty: Ainda não há projetos
-    newProject: Novo projeto
-    updateProject: Atualizar projeto
-    hoursWorked: Horas trabalhadas
-    remainingPayment: Valor a receber
-    reimbursedPayment: Valor a ressarcir
-    hourValue: Valor/hora
-    taskDescription: Tarefa
-    total: Total
-    deleteProject: Excluir projeto
-    deleteProjectWarning: Tem certeza que deseja excluir este projeto?
-    deleteYes: Sim, excluir
-    deleteNo: Não, cancelar
-    working: Trabalhando
-    deleteTaskConfirmationText: Tem certeza que deseja excluir esta tarefa?
-
-    popUpMenuItens:
-      addTask: Adicionar Tarefa
-      managePayments: Gerenciar Pagamentos
-      editProject: Editar Projeto
-
-register:
-  error:
-    initRegister: Erro ao iniciar registro
-    updateRegister: Erro ao atualizar registro
-    resendActivationInstructions: Erro ao reenviar instruções de ativação
-    sendRecoverPasswordInstructions: Erro ao enviar instruções de recuperação de senha
-
-validation:
-  double:
-    invalidFormat: formato inválido
-
-  date:
-    invalidFormat: formato inválido
-
-  id:
-    empty: Não pode ser vazio
-
-  int:
-    invalidFormat: formato inválido
-
-  password:
-    empty: Não pode ser vazio
-    tooShort: muito curta (mínimo de 6 caracteres)
-
-  text:
-    empty: Não pode ser vazio
-
-  failure:
-    notFound: Não foram encontradas falhas
-
-  bool:
-    invalidFormat: Valor booleano em formato inválido
-
-inputs:
-
-  value:
-    hint: Ex.R$ 1.000,00
-    error: Valor inválido
-
-  date:
-    hint: Ex.31/12/2020
-    error: Data inválida
-
-  formatters:
-    date:
-      dayMonthYearInputMask: '##/##/####'
-      dayMonthYear: 'dd/MM/yyyy'
-      monthName: 'MMMM'
-      monthYear: 'MMMM/yyyy'
-      hourMinutes: 'HH:mm'
-      monthDay: 'dd/MM'
-      abbrMonthName: 'MMM'
-      abbrWeekDay: 'EEE'
-
-  tasks:
-    chargeTask: Cobrar Tarefa
-
-    hourValue:
-      title: Valor/Hora
-      hint: Informe o valor da hora trabalhada
-
-    dateBegin: Data de início
-    dateEnd: Data fim
-    standartValue: Valor padrão
-    
-    description:
-      title: Descrição (opcional)
-      hint: Descreva a tarefa
-  
-  email:
-    label: Email
-    hint: Informe seu email
-    error:
-      required: Email é obrigatório
-      invalidFormat: Email em formato inválido
-
-  password:
-    label: Senha
-    hint: Informe sua senha
-    dontMatch: Senhas não conferem
-
-  name:
-    label: Nome
-    hint: Informe seu nome
-
-  confirmPassword:
-    label: Confirmar senha
-    hint: Insira novamente sua senha
-
-  projects:
-    title:
-      title: Título do projeto
-      hint: Projeto Pricemy
-
-    hourValue:
-      title: Valor/Hora
-      hint: Informe o valor da hora trabalhada
-
-    dateBegin:
-      title: Data de início
-
-    dateEnd:
-      title: Data fim
-
-buttons:
-  continue:
-    label: Continuar
-
-  enter:
-    label: Entrar
-
-  back:
-    label: Voltar
-
-  signUp:
-    label: Crie uma conta
-
-  projects:
-    create: Criar
-    update: Atualizar
-
-  tasks:
-    save: Salvar
-
-  register:
-    update: Atualizar
-    deleteAccount: Excluir conta
-
-profile:
-  screen:
-    title: Perfil
-    logout: Desconectar conta
-    chooseLanguage: Escolha o idioma
-    version: Versão
-
-tasks:
-  error:
-    upsertFailed: Falha ao enviar dados da tarefa
-    getFailed: Falha ao coletar tarefas
-    deleteFailed: Falha ao deletar tarefa
-    cacheFailed: Falha ao armazenar as tarefas localmente
-    upsertLocalFailure: Falha ao armazenar tarefa localmente
-    deleteTask: Falha ao deletar tarefa
-    getFromProject: Falha ao recuperar tarefas do projeto
-    start: Falha ao iniciar uma tarefa
-    stop: Falha ao interromper a tarefa
-    alreadyStarted: Já existe uma tarefa iniciada
-    noStartedTask: Sem tarefas iniciadas
-    getRunning: Falha ao recuperar tarefa em execução
-    getUnsynced: Falha ao recuperar tarefas não sincronizadas
-    getUnsyncedDeleted: Falha ao recuperar tarefas deletadas não sincronizadas
-    syncFailed: Falha ao sincronizar tarefas
-
-  screen:
-    newTask: Nova tarefa
-    editTask: Editar tarefa
-
-report:
-  title: Relatório
-  name: Nome
-  date: Data
-  hourBegin: Início
-  hourEnd: Fim
-  hourValue: Valor/hora
-  totalHours: Total de horas
-  totalValue: Valor total
-  description: Descrição
-  value: Valor
-  successMessageSavedIn: Relatório salvo em
-  failedMessage: Falha ao salvar relatório
-  resultTitle: Relatório
-  generatedByPricemy: Gerado por Pricemy
-  remainingValue: Valor a receber
-  paidValue: Valor pago
-  generatedIn: Gerado em
+    title: Conversa
+  generateTarot: Gerar cartas de Tarô
+  input:
+    hint: Digite sua mensagem
+    sending: Enviando...
+  limit:
+    title: Limite atingido
+    message: Sua assinatura permite enviar apenas {limit} mensagem(s).
+conversation:
+  logout:
+    title: Sair
+    message: Deseja realmente sair do aplicativo?
+    cancel: Cancelar
+    confirm: Sair
+  empty: Nenhum significado encontrado
+  new: Novo Significado
+dream:
+  dateLabel: 'Data: '

--- a/lib/app_widget.dart
+++ b/lib/app_widget.dart
@@ -7,6 +7,7 @@ import 'package:my_dreams/core/routes/domain/entities/custom_transition.dart';
 import 'package:my_dreams/core/routes/domain/entities/custom_transition_type.dart';
 import 'package:my_dreams/shared/themes/theme.dart';
 import 'package:my_dreams/shared/utils/global_context.dart';
+import 'package:my_dreams/shared/translate/translate.dart';
 
 class AppWidget extends StatefulWidget {
   const AppWidget({super.key});
@@ -19,7 +20,7 @@ class _AppWidgetState extends State<AppWidget> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'My Dreams AI',
+      title: translate('app.name'),
       debugShowCheckedModeBanner: false,
       navigatorKey: GlobalContext.navigatorKey,
       darkTheme: darkThemeApp,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:my_dreams/core/constants/constants.dart';
 import 'package:my_dreams/core/di/dependency_injection.dart';
 import 'package:my_dreams/shared/services/ads_service.dart';
 import 'package:my_dreams/shared/services/purchase_service.dart';
+import 'package:my_dreams/shared/translate/translate.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 void main() async {
@@ -15,6 +16,10 @@ void main() async {
   await Firebase.initializeApp();
 
   await configureDependencies();
+
+  await I18nTranslate.create(
+    loader: TranslateLoader(basePath: 'assets/i18n'),
+  );
 
   final AdsService ads = getIt<AdsService>();
   await ads.init();

--- a/lib/modules/auth/presentation/auth_page.dart
+++ b/lib/modules/auth/presentation/auth_page.dart
@@ -13,6 +13,7 @@ import 'package:my_dreams/modules/auth/presentation/controller/auth_states.dart'
 import 'package:my_dreams/shared/components/app_circular_indicator_widget.dart';
 import 'package:my_dreams/shared/components/app_snackbar.dart';
 import 'package:my_dreams/shared/themes/app_theme_constants.dart';
+import 'package:my_dreams/shared/translate/translate.dart';
 
 class AuthPage extends StatefulWidget {
   const AuthPage({super.key});
@@ -44,7 +45,7 @@ class _AuthPageState extends State<AuthPage> {
 
         showAppSnackbar(
           context,
-          title: 'Erro',
+          title: translate('common.error'),
           message: state.message,
           type: TypeSnack.error,
         );
@@ -62,7 +63,7 @@ class _AuthPageState extends State<AuthPage> {
     }
 
     return Text(
-      'Entrar com o Google',
+      translate('auth.googleButton'),
       style: context.textTheme.bodyLarge?.copyWith(
         fontWeight: FontWeight.bold,
         color: context.myTheme.surface,
@@ -111,14 +112,14 @@ class _AuthPageState extends State<AuthPage> {
                     ),
                     const SizedBox(height: 20),
                     Text(
-                      'Registre aqui os sonhos que você teve',
+                      translate('auth.screen.title'),
                       style: context.textTheme.headlineMedium?.copyWith(
                         fontWeight: FontWeight.bold,
                       ),
                       textAlign: TextAlign.center,
                     ),
                     const SizedBox(height: 10),
-                    Text('Descubra significados e compartilhe'),
+                    Text(translate('auth.screen.subtitle')),
                   ],
                 ),
                 const SizedBox(height: 30),
@@ -153,7 +154,7 @@ class _AuthPageState extends State<AuthPage> {
                     ),
                     const SizedBox(height: 20),
                     Text(
-                      'Seus sonhos, nosso universo.',
+                      translate('auth.screen.footer'),
                       style: context.textTheme.bodyLarge?.copyWith(),
                       textAlign: TextAlign.center,
                     ),

--- a/lib/modules/chat/presentation/chat_page.dart
+++ b/lib/modules/chat/presentation/chat_page.dart
@@ -10,6 +10,7 @@ import 'package:my_dreams/shared/components/text_form_field.dart';
 import 'package:my_dreams/shared/services/ads_service.dart';
 import 'package:my_dreams/shared/services/purchase_service.dart';
 import 'package:my_dreams/shared/themes/app_theme_constants.dart';
+import 'package:my_dreams/shared/translate/translate.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
 
 import '../../dream/presentation/widgets/chat_message_widget.dart';
@@ -89,8 +90,11 @@ class _ChatPageState extends State<ChatPage> {
     if (sent >= limit) {
       showAppSnackbar(
         context,
-        title: 'Limite atingido',
-        message: 'Sua assinatura permite enviar apenas $limit mensagem(s).',
+        title: translate('chat.limit.title'),
+        message: translate(
+          'chat.limit.message',
+          params: {'limit': '$limit'},
+        ),
         type: TypeSnack.error,
       );
       return;
@@ -118,14 +122,15 @@ class _ChatPageState extends State<ChatPage> {
   void _sendTarotMessage() {
     final user = AppGlobal.instance.user;
     if (user == null) return;
+    final tarotText = translate('chat.generateTarot');
     setState(() {
-      _messages.add(ChatMessage(text: 'Gerar cartas de Tarô', isUser: true));
+      _messages.add(ChatMessage(text: tarotText, isUser: true));
       _isLoading = true;
     });
     _scrollToBottom();
     _bloc.add(
       SendMessageEvent(
-        content: 'Gerar cartas de Tarô',
+        content: tarotText,
         conversationId: _currentConversationId,
         userId: user.id.value,
       ),
@@ -154,7 +159,7 @@ class _ChatPageState extends State<ChatPage> {
     return SafeArea(
       top: false,
       child: Scaffold(
-        appBar: AppBar(title: const Text('Conversa')),
+        appBar: AppBar(title: Text(translate('chat.screen.title'))),
         body: Padding(
           padding: const EdgeInsets.all(AppThemeConstants.padding),
           child: Column(
@@ -187,7 +192,7 @@ class _ChatPageState extends State<ChatPage> {
                       setState(() => _isLoading = false);
                       showAppSnackbar(
                         context,
-                        title: 'Ops...',
+                        title: translate('common.oops'),
                         message: state.message,
                         type: TypeSnack.error,
                       );
@@ -224,7 +229,8 @@ class _ChatPageState extends State<ChatPage> {
                         }
 
                         final hasTaro = _messages.any(
-                          (msg) => msg.text.contains('Gerar cartas de Tarô'),
+                          (msg) =>
+                              msg.text.contains(translate('chat.generateTarot')),
                         );
 
                         if (!hasTaro) {
@@ -237,7 +243,7 @@ class _ChatPageState extends State<ChatPage> {
                                 backgroundColor:
                                     context.myTheme.primaryContainer,
                                 onPressed: _sendTarotMessage,
-                                label: const Text('Gerar cartas de Tarô'),
+                                label: Text(translate('chat.generateTarot')),
                               ),
                               const SizedBox(height: 8),
                             ],
@@ -266,8 +272,8 @@ class _ChatPageState extends State<ChatPage> {
                         readOnly: _isLoading,
                         textArea: true,
                         hint: !_isLoading
-                            ? 'Digite sua mensagem'
-                            : 'Enviando...',
+                            ? translate('chat.input.hint')
+                            : translate('chat.input.sending'),
                         suffixIcon: !_isLoading
                             ? IconButton(
                                 icon: const Icon(Icons.send),

--- a/lib/modules/chat/presentation/conversation_list_page.dart
+++ b/lib/modules/chat/presentation/conversation_list_page.dart
@@ -18,6 +18,7 @@ import 'package:my_dreams/shared/components/spacer_width.dart';
 import 'package:my_dreams/shared/services/ads_service.dart';
 import 'package:my_dreams/shared/services/purchase_service.dart';
 import 'package:my_dreams/shared/themes/app_theme_constants.dart';
+import 'package:my_dreams/shared/translate/translate.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
 
 import '../../home/presentation/widgets/conversation_card_widget.dart';
@@ -59,7 +60,7 @@ class _HomePageState extends State<HomePage> {
 
         showAppSnackbar(
           context,
-          title: 'Erro',
+          title: translate('common.error'),
           message: state.message,
           type: TypeSnack.error,
         );
@@ -95,16 +96,16 @@ class _HomePageState extends State<HomePage> {
       builder: (BuildContext context) {
         return AlertDialog(
           backgroundColor: context.myTheme.primaryContainer,
-          title: const Text('Sair'),
-          content: const Text('Deseja realmente sair do aplicativo?'),
+          title: Text(translate('conversation.logout.title')),
+          content: Text(translate('conversation.logout.message')),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(false),
-              child: const Text('Cancelar'),
+              child: Text(translate('conversation.logout.cancel')),
             ),
             TextButton(
               onPressed: () => Navigator.of(context).pop(true),
-              child: const Text('Sair'),
+              child: Text(translate('conversation.logout.confirm')),
             ),
           ],
         );
@@ -200,8 +201,8 @@ class _HomePageState extends State<HomePage> {
                     }
                     if (state is ChatLoadedConversationsState) {
                       if (state.conversationsList.isEmpty) {
-                        return const Center(
-                          child: Text('Nenhum significado encontrado'),
+                        return Center(
+                          child: Text(translate('conversation.empty')),
                         );
                       }
                       return SuperListView.separated(
@@ -256,7 +257,7 @@ class _HomePageState extends State<HomePage> {
 
           _chatBloc.add(LoadConversationsEvent(userId: user!.id.value));
         },
-        label: const Text('Novo Significado'),
+        label: Text(translate('conversation.new')),
         icon: const Icon(Icons.add),
       ),
     );

--- a/lib/modules/home/presentation/widgets/dream_card_widget.dart
+++ b/lib/modules/home/presentation/widgets/dream_card_widget.dart
@@ -4,6 +4,7 @@ import 'package:my_dreams/modules/dream/domain/entities/dream_entity.dart';
 import 'package:my_dreams/modules/dream/presentation/widgets/chat_message_widget.dart';
 import 'package:my_dreams/shared/themes/app_theme_constants.dart';
 import 'package:my_dreams/shared/utils/formatters.dart';
+import 'package:my_dreams/shared/translate/translate.dart';
 
 class DreamCardWidget extends StatelessWidget {
   final DreamEntity dream;
@@ -29,7 +30,7 @@ class DreamCardWidget extends StatelessWidget {
               Row(
                 children: [
                   Text(
-                    'Data: ',
+                    translate('dream.dateLabel'),
                     style: context.textTheme.bodyMedium?.copyWith(
                       color: context.myTheme.onSurfaceVariant,
                       fontWeight: FontWeight.bold,

--- a/lib/modules/splash/presentation/splash_page.dart
+++ b/lib/modules/splash/presentation/splash_page.dart
@@ -5,6 +5,7 @@ import 'package:my_dreams/core/domain/entities/app_assets.dart';
 import 'package:my_dreams/core/domain/entities/named_routes.dart';
 import 'package:my_dreams/shared/components/app_circular_indicator_widget.dart';
 import 'package:my_dreams/core/constants/constants.dart';
+import 'package:my_dreams/shared/translate/translate.dart';
 
 class SplashPage extends StatefulWidget {
   const SplashPage({super.key});
@@ -68,7 +69,7 @@ class _SplashPageState extends State<SplashPage> {
               ),
               const SizedBox(height: 20),
               Text(
-                'Explore seus sonhos conosco',
+                translate('splash.screen.title'),
                 style: context.textTheme.headlineMedium?.copyWith(
                   fontWeight: FontWeight.bold,
                 ),

--- a/lib/shared/translate/translate.dart
+++ b/lib/shared/translate/translate.dart
@@ -86,3 +86,15 @@ class I18nTranslate {
     return _applyParams(value, params);
   }
 }
+
+String translate(
+  String key, {
+  Map<String, String>? params,
+  String dictId = 'default',
+}) {
+  return I18nTranslate.instance.translate(
+    key,
+    dictId: dictId,
+    params: params,
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,6 +83,7 @@ flutter:
   assets:
     - assets/images/
     - assets/lotties/
+    - assets/i18n/
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images


### PR DESCRIPTION
## Summary
- support i18n with translation loader
- add Portuguese and English dictionaries
- display translated strings in widgets
- initialise translation in `main`
- expose a `translate()` helper

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68813aa1a578832293a9366d6491004c