### PR TITLE
Enable AI responses in both languages

### DIFF
--- a/lib/modules/chat/data/datasources/chat_ai_datasource.dart
+++ b/lib/modules/chat/data/datasources/chat_ai_datasource.dart
@@ -1,7 +1,10 @@
+import 'package:my_dreams/core/domain/entities/app_language.dart';
+
 abstract class ChatAiDatasource {
   Future<String> generateAnswer(
     String prompt, {
     String? summary,
+    required AppLanguage language,
   });
 
   Future<String> generateConversationSummary(String context);

--- a/lib/modules/chat/data/datasources/chat_ai_datasource_impl.dart
+++ b/lib/modules/chat/data/datasources/chat_ai_datasource_impl.dart
@@ -1,5 +1,6 @@
 import 'package:injectable/injectable.dart';
 import 'package:my_dreams/core/data/clients/gemini/gemini_client.dart';
+import 'package:my_dreams/core/domain/entities/app_language.dart';
 
 import 'chat_ai_datasource.dart';
 
@@ -10,14 +11,28 @@ class ChatAiDatasourceImpl implements ChatAiDatasource {
   ChatAiDatasourceImpl({required GeminiClient client}) : _client = client;
 
   @override
-  Future<String> generateAnswer(String prompt, {String? summary}) async {
-    String message = summary != null && summary.isNotEmpty
-        ? 'Resumo do contexto da conversa: $summary\nUsu\u00E1rio: $prompt'
-        : 'Fale o significado do meu sonho, fa\u00E7a um pequeno resumo: $prompt';
+  Future<String> generateAnswer(
+    String prompt, {
+    String? summary,
+    required AppLanguage language,
+  }) async {
+    final bool isEnglish = language == AppLanguage.english;
 
-    if (message.contains('Gerar cartas de Tarô')) {
-      message =
-          'Gerar cartas de Tarô, gere de 3 a 5 cartas e exiba "Carta 1: [título], Carta 2: [título], ...", os títulos não devem conter ** e peça para o usuario escolher uma carta e explique o significado dela, mas de somente o significado e termine a conversa.';
+    String message = summary != null && summary.isNotEmpty
+        ? isEnglish
+            ? 'Conversation context summary: $summary\nUser: $prompt'
+            : 'Resumo do contexto da conversa: $summary\nUsu\u00E1rio: $prompt'
+        : isEnglish
+            ? 'Explain the meaning of my dream, provide a short summary: $prompt'
+            : 'Fale o significado do meu sonho, fa\u00E7a um pequeno resumo: $prompt';
+
+    final tarotCommand =
+        isEnglish ? 'Generate Tarot cards' : 'Gerar cartas de Tarô';
+
+    if (message.contains(tarotCommand)) {
+      message = isEnglish
+          ? 'Generate Tarot cards, generate from 3 to 5 cards and display "Card 1: [title], Card 2: [title], ...", the titles must not contain **. Ask the user to choose one card and explain only its meaning, then finish the conversation.'
+          : 'Gerar cartas de Tarô, gere de 3 a 5 cartas e exiba "Carta 1: [título], Carta 2: [título], ...", os títulos não devem conter ** e peça para o usuario escolher uma carta e explique o significado dela, mas de somente o significado e termine a conversa.';
     }
 
     final data = {

--- a/lib/modules/chat/data/datasources/chat_datasource_impl.dart
+++ b/lib/modules/chat/data/datasources/chat_datasource_impl.dart
@@ -1,9 +1,13 @@
+import 'dart:ui';
+
 import 'package:injectable/injectable.dart';
+
 import 'package:my_dreams/core/data/clients/supabase/supabase_client_interface.dart';
 import 'package:my_dreams/core/domain/entities/tables_db.dart';
 import 'package:my_dreams/modules/chat/data/datasources/chat_ai_datasource.dart';
 import 'package:my_dreams/modules/chat/domain/entities/conversation_entity.dart';
 import 'package:my_dreams/modules/chat/domain/entities/message_entity.dart';
+import 'package:my_dreams/core/domain/entities/app_language.dart';
 
 import '../adapters/conversation_adapter.dart';
 import '../adapters/message_adapter.dart';
@@ -101,9 +105,14 @@ class ChatDatasourceImpl implements ChatDatasource {
       data: MessageAdapter.toMap(userMessage)..remove('id'),
     );
 
+    final language = AppLanguage.fromString(
+      PlatformDispatcher.instance.locale.toString(),
+    );
+
     final aiContent = await _ai.generateAnswer(
       content,
       summary: summary,
+      language: language,
     );
     final aiMessage = MessageEntity(
       id: '',


### PR DESCRIPTION
## Summary
- update `ChatAiDatasource` to accept language
- add English/Portuguese handling in `ChatAiDatasourceImpl`
- provide language info when generating AI answers

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_68813e336c288322b9086a742f1c1f4e