### PR TITLE
Improve splash initialization

### DIFF
--- a/lib/core/init/app_initializer.dart
+++ b/lib/core/init/app_initializer.dart
@@ -1,0 +1,28 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:my_dreams/core/di/dependency_injection.dart';
+import 'package:my_dreams/core/domain/entities/app_config.dart';
+import 'package:my_dreams/shared/services/ads_service.dart';
+import 'package:my_dreams/shared/services/purchase_service.dart';
+import 'package:my_dreams/shared/services/remote_config_service.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// Handles the initialization of application dependencies.
+Future<void> initializeAppDependencies() async {
+  await Firebase.initializeApp();
+
+  final RemoteConfigService remoteConfig = RemoteConfigService();
+  await remoteConfig.init();
+
+  await Supabase.initialize(
+    url: AppConfig.supabaseUrl,
+    anonKey: AppConfig.supabaseAnonKey,
+  );
+
+  await configureDependencies();
+
+  final AdsService ads = getIt<AdsService>();
+  await ads.init();
+
+  final PurchaseService purchase = getIt<PurchaseService>();
+  await purchase.init();
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,35 +1,12 @@
-import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:my_dreams/app_widget.dart';
-import 'package:my_dreams/core/di/dependency_injection.dart';
-import 'package:my_dreams/core/domain/entities/app_config.dart';
-import 'package:my_dreams/shared/services/ads_service.dart';
-import 'package:my_dreams/shared/services/purchase_service.dart';
-import 'package:my_dreams/shared/services/remote_config_service.dart';
 import 'package:my_dreams/shared/translate/translate.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await I18nTranslate.create(loader: TranslateLoader(basePath: 'assets/i18n'));
 
-  await Firebase.initializeApp();
-
-  final RemoteConfigService remoteConfig = RemoteConfigService();
-  await remoteConfig.init();
-
-  await Supabase.initialize(
-    url: AppConfig.supabaseUrl,
-    anonKey: AppConfig.supabaseAnonKey,
-  );
-
-  await configureDependencies();
-
-  final AdsService ads = getIt<AdsService>();
-  await ads.init();
-  final PurchaseService purchase = getIt<PurchaseService>();
-  await purchase.init();
-
   runApp(const AppWidget());
+  // Dependencies are loaded in the splash page.
 }

--- a/lib/modules/splash/presentation/splash_page.dart
+++ b/lib/modules/splash/presentation/splash_page.dart
@@ -4,6 +4,7 @@ import 'package:my_dreams/core/constants/constants.dart';
 import 'package:my_dreams/core/domain/entities/app_assets.dart';
 import 'package:my_dreams/core/domain/entities/app_global.dart';
 import 'package:my_dreams/core/domain/entities/named_routes.dart';
+import 'package:my_dreams/core/init/app_initializer.dart';
 import 'package:my_dreams/shared/components/app_circular_indicator_widget.dart';
 import 'package:my_dreams/shared/themes/app_theme_constants.dart';
 import 'package:my_dreams/shared/translate/translate.dart';
@@ -23,7 +24,7 @@ class _SplashPageState extends State<SplashPage> {
   }
 
   Future<void> _init() async {
-    await Future.delayed(const Duration(seconds: 2));
+    await initializeAppDependencies();
 
     if (!mounted) return;
 


### PR DESCRIPTION
## Summary
- create `AppInitializer` to load dependencies asynchronously
- load dependencies from splash screen to remove long native splash
- update `main.dart` to start the app immediately

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688242ba1f908322ba61fb0622a4ae8c