### PR TITLE
Add initial splash screen with AnimatedSwitcher

### DIFF
--- a/lib/app_widget.dart
+++ b/lib/app_widget.dart
@@ -25,7 +25,7 @@ class _AppWidgetState extends State<AppWidget> {
       navigatorKey: GlobalContext.navigatorKey,
       darkTheme: darkThemeApp,
       themeMode: ThemeMode.dark,
-      initialRoute: NamedRoutes.splash.route,
+      initialRoute: NamedRoutes.initialSplash.route,
       supportedLocales: <Locale>[
         AppLanguage.portuguese.locale,
         AppLanguage.english.locale,

--- a/lib/core/domain/entities/named_routes.dart
+++ b/lib/core/domain/entities/named_routes.dart
@@ -1,4 +1,5 @@
 enum NamedRoutes {
+  initialSplash('/initial-splash'),
   splash('/'),
   auth('/auth'),
   home('/home'),

--- a/lib/core/routes/app_routes.dart
+++ b/lib/core/routes/app_routes.dart
@@ -3,6 +3,7 @@ import 'package:my_dreams/modules/auth/presentation/auth_page.dart';
 import 'package:my_dreams/modules/chat/presentation/chat_page.dart';
 import 'package:my_dreams/modules/home/presentation/home_page.dart';
 import 'package:my_dreams/modules/splash/presentation/splash_page.dart';
+import 'package:my_dreams/modules/splash/presentation/initial_splash_page.dart';
 import 'package:my_dreams/modules/subscription/presentation/subscription_page.dart';
 
 import '../domain/entities/named_routes.dart';
@@ -16,6 +17,8 @@ class CustomNavigator {
 
   Route<dynamic>? onGenerateRoute(RouteSettings settings) {
     final Map<String, WidgetBuilder> appRoutes = <String, WidgetBuilder>{
+      NamedRoutes.initialSplash.route:
+          (BuildContext context) => const InitialSplashPage(),
       NamedRoutes.splash.route: (BuildContext context) => const SplashPage(),
       NamedRoutes.auth.route: (BuildContext context) => const AuthPage(),
       NamedRoutes.home.route: (BuildContext context) => const HomePage(),

--- a/lib/modules/splash/presentation/initial_splash_page.dart
+++ b/lib/modules/splash/presentation/initial_splash_page.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:my_dreams/core/init/app_initializer.dart';
+
+import 'splash_content.dart';
+import 'splash_page.dart';
+
+class InitialSplashPage extends StatefulWidget {
+  const InitialSplashPage({super.key});
+
+  @override
+  State<InitialSplashPage> createState() => _InitialSplashPageState();
+}
+
+class _InitialSplashPageState extends State<InitialSplashPage> {
+  bool _showMainSplash = false;
+
+  @override
+  void initState() {
+    super.initState();
+
+    SystemChrome.setSystemUIOverlayStyle(
+      const SystemUiOverlayStyle(
+        statusBarIconBrightness: Brightness.light,
+        statusBarBrightness: Brightness.light,
+      ),
+    );
+
+    _loadDependencies();
+  }
+
+  Future<void> _loadDependencies() async {
+    await initializeAppDependencies();
+
+    if (!mounted) return;
+
+    setState(() => _showMainSplash = true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      child: _showMainSplash ? const SplashPage() : const SplashContent(),
+    );
+  }
+}

--- a/lib/modules/splash/presentation/splash_content.dart
+++ b/lib/modules/splash/presentation/splash_content.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:my_dreams/core/constants/constants.dart';
+import 'package:my_dreams/core/domain/entities/app_assets.dart';
+import 'package:my_dreams/shared/components/app_circular_indicator_widget.dart';
+import 'package:my_dreams/shared/themes/app_theme_constants.dart';
+import 'package:my_dreams/shared/translate/translate.dart';
+
+class SplashContent extends StatelessWidget {
+  const SplashContent({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(AppThemeConstants.mediumPadding),
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Image.asset(AppAssets.logo, width: context.screenWidth * .5),
+                const SizedBox(height: 20),
+                Text(
+                  translate('splash.screen.title'),
+                  style: context.textTheme.headlineMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 40),
+                const AppCircularIndicatorWidget(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/splash/presentation/splash_page.dart
+++ b/lib/modules/splash/presentation/splash_page.dart
@@ -1,13 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:my_dreams/core/constants/constants.dart';
-import 'package:my_dreams/core/domain/entities/app_assets.dart';
 import 'package:my_dreams/core/domain/entities/app_global.dart';
 import 'package:my_dreams/core/domain/entities/named_routes.dart';
 import 'package:my_dreams/core/init/app_initializer.dart';
-import 'package:my_dreams/shared/components/app_circular_indicator_widget.dart';
-import 'package:my_dreams/shared/themes/app_theme_constants.dart';
 import 'package:my_dreams/shared/translate/translate.dart';
+
+import 'splash_content.dart';
 
 class SplashPage extends StatefulWidget {
   const SplashPage({super.key});
@@ -59,30 +57,6 @@ class _SplashPageState extends State<SplashPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(AppThemeConstants.mediumPadding),
-          child: Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Image.asset(AppAssets.logo, width: context.screenWidth * .5),
-                const SizedBox(height: 20),
-                Text(
-                  translate('splash.screen.title'),
-                  style: context.textTheme.headlineMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 40),
-                const AppCircularIndicatorWidget(),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
+    return const SplashContent();
   }
 }


### PR DESCRIPTION
## Summary
- add `SplashContent` widget for reuse
- create `InitialSplashPage` with animated transition to `SplashPage`
- update navigation routes and initial route

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688248e010ac83229cc3fb9952e333e9