### PR TITLE
Update plan benefits and show discount prices

### DIFF
--- a/assets/i18n/en_US.yaml
+++ b/assets/i18n/en_US.yaml
@@ -34,6 +34,12 @@ purchase:
   weeklyPrice: "$4.99"
   monthlyPrice: "$9.99"
   annualPrice: "$49.99"
+  weeklyOldPrice: "$5.99"
+  monthlyOldPrice: "$12.99"
+  annualOldPrice: "$59.99"
+  removeAds: Remove ads
+  fiveDreamMeanings: 5 dream meanings
+  tarotCards: Generate Tarot cards
   weeklyBenefits: Unlimited chats for 7 days
   monthlyBenefits: Unlimited chats for 30 days
   annualBenefits: Unlimited chats for 1 year

--- a/assets/i18n/pt_BR.yaml
+++ b/assets/i18n/pt_BR.yaml
@@ -34,6 +34,12 @@ purchase:
   weeklyPrice: "R$ 4,99"
   monthlyPrice: "R$ 9,99"
   annualPrice: "R$ 49,99"
+  weeklyOldPrice: "R$ 6,99"
+  monthlyOldPrice: "R$ 12,99"
+  annualOldPrice: "R$ 59,99"
+  removeAds: Remover anúncios
+  fiveDreamMeanings: 5 significados dos sonhos
+  tarotCards: Gerar cartas de Tarô
   weeklyBenefits: Acesso por 7 dias, conversas ilimitadas
   monthlyBenefits: Acesso por 30 dias, conversas ilimitadas
   annualBenefits: Acesso por 1 ano, conversas ilimitadas

--- a/lib/modules/subscription/presentation/subscription_page.dart
+++ b/lib/modules/subscription/presentation/subscription_page.dart
@@ -88,7 +88,12 @@ class _SubscriptionPageState extends State<SubscriptionPage> {
               price: _purchase.priceFor(PurchaseService.weeklyId).isNotEmpty
                   ? _purchase.priceFor(PurchaseService.weeklyId)
                   : translate('purchase.weeklyPrice'),
-              benefits: [translate('purchase.weeklyBenefits')],
+              oldPrice: translate('purchase.weeklyOldPrice'),
+              benefits: [
+                translate('purchase.removeAds'),
+                translate('purchase.fiveDreamMeanings'),
+                translate('purchase.tarotCards'),
+              ],
               isActive: AppGlobal.instance.plan == SubscriptionPlan.weekly,
               onTap: () => _purchase.buy(PurchaseService.weeklyId),
             ),
@@ -98,7 +103,12 @@ class _SubscriptionPageState extends State<SubscriptionPage> {
               price: _purchase.priceFor(PurchaseService.monthlyId).isNotEmpty
                   ? _purchase.priceFor(PurchaseService.monthlyId)
                   : translate('purchase.monthlyPrice'),
-              benefits: [translate('purchase.monthlyBenefits')],
+              oldPrice: translate('purchase.monthlyOldPrice'),
+              benefits: [
+                translate('purchase.removeAds'),
+                translate('purchase.fiveDreamMeanings'),
+                translate('purchase.tarotCards'),
+              ],
               isActive: AppGlobal.instance.plan == SubscriptionPlan.monthly,
               onTap: () => _purchase.buy(PurchaseService.monthlyId),
             ),
@@ -108,7 +118,12 @@ class _SubscriptionPageState extends State<SubscriptionPage> {
               price: _purchase.priceFor(PurchaseService.annualId).isNotEmpty
                   ? _purchase.priceFor(PurchaseService.annualId)
                   : translate('purchase.annualPrice'),
-              benefits: [translate('purchase.annualBenefits')],
+              oldPrice: translate('purchase.annualOldPrice'),
+              benefits: [
+                translate('purchase.removeAds'),
+                translate('purchase.fiveDreamMeanings'),
+                translate('purchase.tarotCards'),
+              ],
               isActive: AppGlobal.instance.plan == SubscriptionPlan.annual,
               onTap: () => _purchase.buy(PurchaseService.annualId),
             ),

--- a/lib/modules/subscription/presentation/widgets/plan_card_widget.dart
+++ b/lib/modules/subscription/presentation/widgets/plan_card_widget.dart
@@ -5,6 +5,7 @@ import 'package:my_dreams/shared/themes/app_theme_constants.dart';
 class PlanCardWidget extends StatelessWidget {
   final String title;
   final String price;
+  final String? oldPrice;
   final List<String> benefits;
   final VoidCallback onTap;
   final bool isActive;
@@ -15,6 +16,7 @@ class PlanCardWidget extends StatelessWidget {
     required this.price,
     required this.benefits,
     required this.onTap,
+    this.oldPrice,
     this.isActive = false,
   });
 
@@ -45,7 +47,27 @@ class PlanCardWidget extends StatelessWidget {
                   Expanded(
                     child: Text(title, style: context.textTheme.titleMedium),
                   ),
-                  Text(price, style: context.textTheme.titleMedium),
+                  if (oldPrice != null && oldPrice!.isNotEmpty)
+                    Text.rich(
+                      TextSpan(
+                        text: price,
+                        style: context.textTheme.titleMedium,
+                        children: [
+                          TextSpan(
+                            text: ' de ',
+                            style: context.textTheme.bodyMedium,
+                          ),
+                          TextSpan(
+                            text: oldPrice,
+                            style: context.textTheme.bodyMedium?.copyWith(
+                              decoration: TextDecoration.lineThrough,
+                            ),
+                          ),
+                        ],
+                      ),
+                    )
+                  else
+                    Text(price, style: context.textTheme.titleMedium),
                 ],
               ),
               const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- show strike-through discount pricing in `PlanCardWidget`
- list new plan benefits about ad removal, dream meanings and tarot
- update subscription page to show benefits and old price
- update translations for new price format and benefits in English and Portuguese

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882e1ac25908322a7b5774e0fadb8c1