### PR TITLE
Remove price translations and compute dynamic offers

### DIFF
--- a/assets/i18n/en_US.yaml
+++ b/assets/i18n/en_US.yaml
@@ -31,12 +31,6 @@ purchase:
   monthly: Monthly Plan
   annual: Annual Plan
   free: Free Plan
-  weeklyPrice: "$4.99"
-  monthlyPrice: "$9.99"
-  annualPrice: "$49.99"
-  weeklyOldPrice: "$5.99"
-  monthlyOldPrice: "$12.99"
-  annualOldPrice: "$59.99"
   removeAds: Remove ads
   fiveDreamMeanings: 5 dream meanings
   tarotCards: Generate Tarot cards

--- a/assets/i18n/pt_BR.yaml
+++ b/assets/i18n/pt_BR.yaml
@@ -31,12 +31,6 @@ purchase:
   monthly: Plano Mensal
   annual: Plano Anual
   free: Plano Gratuito
-  weeklyPrice: "R$ 4,99"
-  monthlyPrice: "R$ 9,99"
-  annualPrice: "R$ 49,99"
-  weeklyOldPrice: "R$ 6,99"
-  monthlyOldPrice: "R$ 12,99"
-  annualOldPrice: "R$ 59,99"
   removeAds: Remover anúncios
   fiveDreamMeanings: 5 significados dos sonhos
   tarotCards: Gerar cartas de Tarô

--- a/lib/modules/subscription/presentation/subscription_page.dart
+++ b/lib/modules/subscription/presentation/subscription_page.dart
@@ -10,6 +10,7 @@ import 'package:my_dreams/shared/components/app_snackbar.dart';
 import 'package:my_dreams/shared/services/purchase_service.dart';
 import 'package:my_dreams/shared/themes/app_theme_constants.dart';
 import 'package:my_dreams/shared/translate/translate.dart';
+import 'package:my_dreams/shared/utils/price_utils.dart';
 
 import 'widgets/plan_card_widget.dart';
 
@@ -85,10 +86,11 @@ class _SubscriptionPageState extends State<SubscriptionPage> {
             const SizedBox(height: 16),
             PlanCardWidget(
               title: translate('purchase.weekly'),
-              price: _purchase.priceFor(PurchaseService.weeklyId).isNotEmpty
-                  ? _purchase.priceFor(PurchaseService.weeklyId)
-                  : translate('purchase.weeklyPrice'),
-              oldPrice: translate('purchase.weeklyOldPrice'),
+              price: _purchase.priceFor(PurchaseService.weeklyId),
+              oldPrice: PriceUtils.addAmount(
+                _purchase.priceFor(PurchaseService.weeklyId),
+                2,
+              ),
               benefits: [
                 translate('purchase.removeAds'),
                 translate('purchase.fiveDreamMeanings'),
@@ -100,10 +102,11 @@ class _SubscriptionPageState extends State<SubscriptionPage> {
             const SizedBox(height: 8),
             PlanCardWidget(
               title: translate('purchase.monthly'),
-              price: _purchase.priceFor(PurchaseService.monthlyId).isNotEmpty
-                  ? _purchase.priceFor(PurchaseService.monthlyId)
-                  : translate('purchase.monthlyPrice'),
-              oldPrice: translate('purchase.monthlyOldPrice'),
+              price: _purchase.priceFor(PurchaseService.monthlyId),
+              oldPrice: PriceUtils.addAmount(
+                _purchase.priceFor(PurchaseService.monthlyId),
+                15,
+              ),
               benefits: [
                 translate('purchase.removeAds'),
                 translate('purchase.fiveDreamMeanings'),
@@ -115,10 +118,11 @@ class _SubscriptionPageState extends State<SubscriptionPage> {
             const SizedBox(height: 8),
             PlanCardWidget(
               title: translate('purchase.annual'),
-              price: _purchase.priceFor(PurchaseService.annualId).isNotEmpty
-                  ? _purchase.priceFor(PurchaseService.annualId)
-                  : translate('purchase.annualPrice'),
-              oldPrice: translate('purchase.annualOldPrice'),
+              price: _purchase.priceFor(PurchaseService.annualId),
+              oldPrice: PriceUtils.addAmount(
+                _purchase.priceFor(PurchaseService.annualId),
+                50,
+              ),
               benefits: [
                 translate('purchase.removeAds'),
                 translate('purchase.fiveDreamMeanings'),

--- a/lib/shared/utils/price_utils.dart
+++ b/lib/shared/utils/price_utils.dart
@@ -1,0 +1,35 @@
+import 'package:intl/intl.dart';
+
+/// Utility functions for price manipulation.
+class PriceUtils {
+  /// Returns [price] with [amount] added to its numeric value.
+  ///
+  /// The currency prefix and decimal separator are preserved.
+  static String addAmount(String price, double amount) {
+    if (price.isEmpty) return '';
+
+    final match = RegExp(r'([0-9.,]+)').firstMatch(price);
+    if (match == null) return price;
+
+    final prefix = price.substring(0, match.start);
+    final suffix = price.substring(match.end);
+    final digits = match.group(1)!;
+
+    final usesComma = digits.contains(',') &&
+        digits.lastIndexOf(',') > digits.lastIndexOf('.');
+    final normalized = usesComma
+        ? digits.replaceAll('.', '').replaceAll(',', '.')
+        : digits.replaceAll(',', '');
+
+    final value = double.tryParse(normalized);
+    if (value == null) return price;
+
+    final newValue = value + amount;
+    var formatted = NumberFormat('0.00').format(newValue);
+    if (usesComma) {
+      formatted = formatted.replaceAll('.', ',');
+    }
+
+    return '$prefix$formatted$suffix';
+  }
+}


### PR DESCRIPTION
## Summary
- compute old price based on current purchase price
- drop static plan prices from translations
- show dynamic prices in subscription page

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882e4be08088322b6fd8f4034b2905c