### PR TITLE
Use remote config for premium limit

### DIFF
--- a/lib/core/domain/entities/app_config.dart
+++ b/lib/core/domain/entities/app_config.dart
@@ -2,4 +2,5 @@ class AppConfig {
   static String supabaseUrl = '';
   static String supabaseAnonKey = '';
   static String geminiApiKey = '';
+  static int premiumLimit = 5;
 }

--- a/lib/modules/chat/presentation/chat_page.dart
+++ b/lib/modules/chat/presentation/chat_page.dart
@@ -7,6 +7,7 @@ import 'package:my_dreams/shared/components/app_circular_indicator_widget.dart';
 import 'package:my_dreams/shared/components/app_snackbar.dart';
 import 'package:my_dreams/shared/components/custom_button.dart';
 import 'package:my_dreams/shared/components/text_form_field.dart';
+import 'package:my_dreams/core/domain/entities/app_config.dart';
 import 'package:my_dreams/shared/services/ads_service.dart';
 import 'package:my_dreams/shared/services/purchase_service.dart';
 import 'package:my_dreams/shared/themes/app_theme_constants.dart';
@@ -89,7 +90,8 @@ class _ChatPageState extends State<ChatPage> {
     final text = _controller.text.trim();
     if (user == null || text.isEmpty) return;
 
-    final int limit = _purchase.isPremium ? 5 : 1;
+    final int limit =
+        _purchase.isPremium ? AppConfig.premiumLimit : 1;
     final int sent = _messages.where((m) => m.isUser).length;
     if (sent >= limit) {
       return;

--- a/lib/modules/chat/presentation/conversation_list_page.dart
+++ b/lib/modules/chat/presentation/conversation_list_page.dart
@@ -19,6 +19,7 @@ import 'package:my_dreams/shared/components/spacer_height_widget.dart';
 import 'package:my_dreams/shared/components/spacer_width.dart';
 import 'package:my_dreams/shared/services/ads_service.dart';
 import 'package:my_dreams/shared/services/purchase_service.dart';
+import 'package:my_dreams/core/domain/entities/app_config.dart';
 import 'package:my_dreams/shared/themes/app_theme_constants.dart';
 import 'package:my_dreams/shared/translate/translate.dart';
 import 'package:my_dreams/shared/utils/formatters.dart';
@@ -125,7 +126,8 @@ class _HomePageState extends State<HomePage> {
   }
 
   bool _canCreateConversation(List<ConversationEntity> list) {
-    final int limit = _purchase.isPremium ? 5 : 1;
+    final int limit =
+        _purchase.isPremium ? AppConfig.premiumLimit : 1;
     final now = DateTime.now();
     final todayCount = list
         .where((conv) => conv.createdAt.value.isSameDate(now))

--- a/lib/shared/services/remote_config_service.dart
+++ b/lib/shared/services/remote_config_service.dart
@@ -30,5 +30,10 @@ class RemoteConfigService {
     if (geminiKey.isNotEmpty) {
       AppConfig.geminiApiKey = geminiKey;
     }
+
+    final premiumLimit = _remoteConfig.getInt('PREMIUM_LIMIT');
+    if (premiumLimit > 0) {
+      AppConfig.premiumLimit = premiumLimit;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add new premium limit field to app configuration
- read premium limit from remote config service
- use configured limit in chat and conversation pages

## Testing
- `dart format lib/core/domain/entities/app_config.dart lib/shared/services/remote_config_service.dart lib/modules/chat/presentation/chat_page.dart lib/modules/chat/presentation/conversation_list_page.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883cc95384083229decc85fa09794ad