### PR TITLE
Update premium limits based on subscription plan

### DIFF
--- a/lib/core/domain/entities/app_config.dart
+++ b/lib/core/domain/entities/app_config.dart
@@ -1,6 +1,21 @@
+import 'subscription_plan.dart';
+
 class AppConfig {
   static String supabaseUrl = '';
   static String supabaseAnonKey = '';
   static String geminiApiKey = '';
-  static int premiumLimit = 5;
+
+  static final Map<SubscriptionPlan, int> _premiumLimits = {
+    SubscriptionPlan.weekly: 5,
+    SubscriptionPlan.monthly: 10,
+    SubscriptionPlan.annual: 20,
+  };
+
+  static int limitForPlan(SubscriptionPlan plan) => _premiumLimits[plan] ?? 1;
+
+  static void updateLimitForPlan(SubscriptionPlan plan, int limit) {
+    if (limit > 0) {
+      _premiumLimits[plan] = limit;
+    }
+  }
 }

--- a/lib/modules/chat/presentation/chat_page.dart
+++ b/lib/modules/chat/presentation/chat_page.dart
@@ -90,7 +90,9 @@ class _ChatPageState extends State<ChatPage> {
     final text = _controller.text.trim();
     if (user == null || text.isEmpty) return;
 
-    final int limit = _purchase.isPremium ? AppConfig.premiumLimit : 1;
+    final int limit = _purchase.isPremium
+        ? AppConfig.limitForPlan(AppGlobal.instance.plan)
+        : 1;
     final int sent = _messages.where((m) => m.isUser).length;
     if (sent >= limit) {
       return;

--- a/lib/modules/chat/presentation/conversation_list_page.dart
+++ b/lib/modules/chat/presentation/conversation_list_page.dart
@@ -127,7 +127,9 @@ class _HomePageState extends State<HomePage> {
   }
 
   bool _canCreateConversation(List<ConversationEntity> list) {
-    final int limit = _purchase.isPremium ? AppConfig.premiumLimit : 1;
+    final int limit = _purchase.isPremium
+        ? AppConfig.limitForPlan(AppGlobal.instance.plan)
+        : 1;
     final now = DateTime.now();
     final todayCount = list
         .where((conv) => conv.createdAt.value.isSameDate(now))

--- a/lib/shared/services/remote_config_service.dart
+++ b/lib/shared/services/remote_config_service.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:injectable/injectable.dart';
 import 'package:my_dreams/core/domain/entities/app_config.dart';
+import 'package:my_dreams/core/domain/entities/subscription_plan.dart';
 
 @singleton
 class RemoteConfigService {
@@ -31,9 +32,19 @@ class RemoteConfigService {
       AppConfig.geminiApiKey = geminiKey;
     }
 
-    final premiumLimit = _remoteConfig.getInt('PREMIUM_LIMIT');
-    if (premiumLimit > 0) {
-      AppConfig.premiumLimit = premiumLimit;
+    final weeklyLimit = _remoteConfig.getInt('WEEKLY_PREMIUM_LIMIT');
+    if (weeklyLimit > 0) {
+      AppConfig.updateLimitForPlan(SubscriptionPlan.weekly, weeklyLimit);
+    }
+
+    final monthlyLimit = _remoteConfig.getInt('MONTHLY_PREMIUM_LIMIT');
+    if (monthlyLimit > 0) {
+      AppConfig.updateLimitForPlan(SubscriptionPlan.monthly, monthlyLimit);
+    }
+
+    final annualLimit = _remoteConfig.getInt('ANNUAL_PREMIUM_LIMIT');
+    if (annualLimit > 0) {
+      AppConfig.updateLimitForPlan(SubscriptionPlan.annual, annualLimit);
     }
   }
 }


### PR DESCRIPTION
## Summary
- store premium limits per plan in AppConfig
- load ANNUAL/MONTHLY/WEEKLY limits from RemoteConfig
- apply plan-based limit on chat and conversation creation

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883ed2cbf708322ad4cad095bd7da3c