### PR TITLE
Update plan cards to show daily dream limits

### DIFF
--- a/assets/i18n/en_US.yaml
+++ b/assets/i18n/en_US.yaml
@@ -32,6 +32,7 @@ purchase:
   annual: Annual Plan
   free: Free Plan
   removeAds: Remove ads
+  dreamsPerDay: '{limit} dreams per day'
   fiveDreamMeanings: 5 dream meanings
   tarotCards: Generate Tarot cards
   current: Current plan - {plan}

--- a/assets/i18n/pt_BR.yaml
+++ b/assets/i18n/pt_BR.yaml
@@ -32,6 +32,7 @@ purchase:
   annual: Plano Anual
   free: Plano Gratuito
   removeAds: Remover anúncios
+  dreamsPerDay: '{limit} sonhos por dia'
   fiveDreamMeanings: 5 significados dos sonhos
   tarotCards: Gerar cartas de Tarô
   current: Plano atual - {plan}

--- a/lib/modules/subscription/presentation/subscription_page.dart
+++ b/lib/modules/subscription/presentation/subscription_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:my_dreams/core/di/dependency_injection.dart';
 import 'package:my_dreams/core/domain/entities/app_global.dart';
 import 'package:my_dreams/core/domain/entities/subscription_plan.dart';
+import 'package:my_dreams/core/domain/entities/app_config.dart';
 import 'package:my_dreams/modules/subscription/domain/entities/purchase_state.dart';
 import 'package:my_dreams/shared/components/app_circular_indicator_widget.dart';
 import 'package:my_dreams/shared/components/app_snackbar.dart';
@@ -87,7 +88,10 @@ class _SubscriptionPageState extends State<SubscriptionPage> {
                 ),
                 benefits: [
                   translate('purchase.removeAds'),
-                  translate('purchase.fiveDreamMeanings'),
+                  translate(
+                    'purchase.dreamsPerDay',
+                    params: {'limit': '${AppConfig.limitForPlan(SubscriptionPlan.weekly)}'},
+                  ),
                   translate('purchase.tarotCards'),
                 ],
                 isActive: AppGlobal.instance.plan == SubscriptionPlan.weekly,
@@ -103,7 +107,10 @@ class _SubscriptionPageState extends State<SubscriptionPage> {
                 ),
                 benefits: [
                   translate('purchase.removeAds'),
-                  translate('purchase.fiveDreamMeanings'),
+                  translate(
+                    'purchase.dreamsPerDay',
+                    params: {'limit': '${AppConfig.limitForPlan(SubscriptionPlan.monthly)}'},
+                  ),
                   translate('purchase.tarotCards'),
                 ],
                 isActive: AppGlobal.instance.plan == SubscriptionPlan.monthly,
@@ -119,7 +126,10 @@ class _SubscriptionPageState extends State<SubscriptionPage> {
                 ),
                 benefits: [
                   translate('purchase.removeAds'),
-                  translate('purchase.fiveDreamMeanings'),
+                  translate(
+                    'purchase.dreamsPerDay',
+                    params: {'limit': '${AppConfig.limitForPlan(SubscriptionPlan.annual)}'},
+                  ),
                   translate('purchase.tarotCards'),
                 ],
                 isActive: AppGlobal.instance.plan == SubscriptionPlan.annual,


### PR DESCRIPTION
## Summary
- add `dreamsPerDay` translation for displaying daily dream limits
- show daily dream limits in the subscription plan cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883ef5c5c9c8322bcd020068e253b7d